### PR TITLE
feat: implement JWT authentication, RBAC, and database migration system

### DIFF
--- a/backend/apperrors/errors.go
+++ b/backend/apperrors/errors.go
@@ -16,6 +16,9 @@ const (
 	CodeDatabaseError        ErrorCode = "database_error"
 	CodeExternalServiceError ErrorCode = "external_service_error"
 	CodeUnauthorized         ErrorCode = "unauthorized"
+	CodeForbidden            ErrorCode = "forbidden"
+	CodeConflict             ErrorCode = "conflict"
+	CodeTooManyRequests      ErrorCode = "too_many_requests"
 )
 
 type AppError struct {
@@ -104,4 +107,44 @@ func FormatErrorResponse(err *AppError, requestID string, debug bool) ErrorRespo
 	}
 
 	return resp
+}
+
+func NewValidationError(message string, err error) *AppError {
+	return Wrap(err, CodeValidationFailed, message, http.StatusBadRequest)
+}
+
+func NewBadRequestError(message string) *AppError {
+	return New(CodeBadRequest, message, http.StatusBadRequest)
+}
+
+func NewNotFoundError(message string) *AppError {
+	return New(CodeNotFound, message, http.StatusNotFound)
+}
+
+func NewUnauthorizedError(message string) *AppError {
+	return New(CodeUnauthorized, message, http.StatusUnauthorized)
+}
+
+func NewForbiddenError(message string) *AppError {
+	return New(CodeForbidden, message, http.StatusForbidden)
+}
+
+func NewConflictError(message string) *AppError {
+	return New(CodeConflict, message, http.StatusConflict)
+}
+
+func NewInternalError(message string) *AppError {
+	return New(CodeInternalServerError, message, http.StatusInternalServerError)
+}
+
+func NewTooManyRequestsError(message string) *AppError {
+	return New(CodeTooManyRequests, message, http.StatusTooManyRequests)
+}
+
+func NewDatabaseError(message string, err error) *AppError {
+	return Wrap(err, CodeDatabaseError, message, http.StatusInternalServerError)
+}
+
+func NewExternalServiceError(message string, err error) *AppError {
+	return Wrap(err, CodeExternalServiceError, message, http.StatusBadGateway)
 }

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/joho/godotenv"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/yourusername/kor-assetforge/migrations"
+)
+
+func main() {
+	_ = godotenv.Load()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "host=localhost user=postgres password=password dbname=assetforge port=5432 sslmode=disable"
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		log.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+
+	m := migrations.New(db)
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `Usage: migrate <command> [args]
+
+Commands:
+  up              Apply all pending migrations
+  down [n]        Roll back n migrations (default: 1; use 0 for all)
+  status          Show applied migrations
+  version         Show current migration version
+`)
+	}
+	flag.Parse()
+
+	cmd := flag.Arg(0)
+	switch cmd {
+	case "up":
+		if err := m.Up(); err != nil {
+			log.Fatalf("migrate up: %v", err)
+		}
+
+	case "down":
+		n := 1
+		if arg := flag.Arg(1); arg != "" {
+			v, err := strconv.Atoi(arg)
+			if err != nil {
+				log.Fatalf("invalid count %q: %v", arg, err)
+			}
+			n = v
+		}
+		if err := m.Down(n); err != nil {
+			log.Fatalf("migrate down: %v", err)
+		}
+
+	case "status":
+		records, err := m.Status()
+		if err != nil {
+			log.Fatalf("migrate status: %v", err)
+		}
+		if len(records) == 0 {
+			fmt.Println("No migrations applied.")
+			return
+		}
+		fmt.Printf("%-8s %-40s %s\n", "VERSION", "NAME", "APPLIED AT")
+		fmt.Println(string(make([]byte, 70)))
+		for _, r := range records {
+			fmt.Printf("%-8d %-40s %s\n", r.Version, r.Name, r.AppliedAt.Format("2006-01-02 15:04:05"))
+		}
+
+	case "version":
+		v, err := m.Version()
+		if err != nil {
+			log.Fatalf("migrate version: %v", err)
+		}
+		fmt.Printf("current version: %d\n", v)
+
+	default:
+		flag.Usage()
+		os.Exit(1)
+	}
+}

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -1,41 +1,58 @@
 package config
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 	"time"
 
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/yourusername/kor-assetforge/migrations"
 	"github.com/yourusername/kor-assetforge/models"
 	"github.com/yourusername/kor-assetforge/utils"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
-// InitDB initializes the database connection and auto-migrates all models.
+// InitDB initializes the database connection, runs SQL migrations, then GORM AutoMigrate.
 func InitDB() (*gorm.DB, error) {
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
 		dsn = "host=localhost user=postgres password=password dbname=assetforge port=5432 sslmode=disable"
 	}
 
+	// Run versioned SQL migrations first
+	rawDB, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+	defer rawDB.Close()
+
+	if err := migrations.New(rawDB).Up(); err != nil {
+		return nil, fmt.Errorf("failed to apply migrations: %w", err)
+	}
+
+	// Open GORM connection for the rest of the application
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 
+	// GORM AutoMigrate handles columns added after the initial SQL migration
 	if err := db.AutoMigrate(
 		&models.Asset{},
 		&models.Listing{},
 		&models.Transaction{},
 		&models.User{},
 		&models.UserBalance{},
+		&models.UserSession{},
 		// KYC / AML models (#55)
 		&models.KYCRecord{},
 		&models.KYCDocument{},
 		&models.AMLScreening{},
 		&models.ComplianceAuditLog{},
 	); err != nil {
-		return nil, fmt.Errorf("failed to migrate database: %w", err)
+		return nil, fmt.Errorf("failed to auto-migrate models: %w", err)
 	}
 
 	return db, nil

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,11 +7,13 @@ toolchain go1.24.13
 require (
 	github.com/alicebob/miniredis/v2 v2.31.1
 	github.com/gin-gonic/gin v1.9.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/stellar/go v0.0.0-20251210100531-aab2ea4aca88
 	go.uber.org/zap v1.26.0
+	golang.org/x/time v0.5.0
 	gorm.io/driver/postgres v1.5.4
 	gorm.io/gorm v1.25.5
 )

--- a/backend/handlers/auth/auth.go
+++ b/backend/handlers/auth/auth.go
@@ -1,0 +1,412 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+
+	"github.com/yourusername/kor-assetforge/apperrors"
+	"github.com/yourusername/kor-assetforge/models"
+)
+
+// AuthConfig holds authentication configuration
+type AuthConfig struct {
+	JWTSecret          string
+	JWTExpirationHours int
+	RefreshTokenHours  int
+	EmailTokenHours    int
+	PasswordResetHours int
+	BcryptCost         int
+}
+
+// AuthHandler handles authentication operations
+type AuthHandler struct {
+	db     *gorm.DB
+	config *AuthConfig
+}
+
+// NewAuthHandler creates a new auth handler
+func NewAuthHandler(db *gorm.DB, config *AuthConfig) *AuthHandler {
+	return &AuthHandler{db: db, config: config}
+}
+
+// RegisterRequest represents user registration request
+type RegisterRequest struct {
+	StellarAddress string `json:"stellar_address" binding:"required"`
+	Email          string `json:"email" binding:"required,email"`
+	Username       string `json:"username" binding:"required,min=3,max=50"`
+	Password       string `json:"password" binding:"required,min=8"`
+}
+
+// LoginRequest represents user login request
+type LoginRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+}
+
+// TokenResponse represents JWT token response
+type TokenResponse struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	TokenType    string    `json:"token_type"`
+	ExpiresIn    int64     `json:"expires_in"`
+	User         UserInfo  `json:"user"`
+}
+
+// UserInfo represents user information in responses
+type UserInfo struct {
+	ID             uint       `json:"id"`
+	StellarAddress string     `json:"stellar_address"`
+	Email          string     `json:"email"`
+	Username       string     `json:"username"`
+	Role           string     `json:"role"`
+	EmailVerified  bool       `json:"email_verified"`
+	KYCVerified    bool       `json:"kyc_verified"`
+	LastLoginAt    *time.Time `json:"last_login_at,omitempty"`
+}
+
+// RefreshTokenRequest represents token refresh request
+type RefreshTokenRequest struct {
+	RefreshToken string `json:"refresh_token" binding:"required"`
+}
+
+// VerifyEmailRequest represents email verification request
+type VerifyEmailRequest struct {
+	Token string `json:"token" binding:"required"`
+}
+
+// ForgotPasswordRequest represents forgot password request
+type ForgotPasswordRequest struct {
+	Email string `json:"email" binding:"required,email"`
+}
+
+// ResetPasswordRequest represents password reset request
+type ResetPasswordRequest struct {
+	Token    string `json:"token" binding:"required"`
+	Password string `json:"password" binding:"required,min=8"`
+}
+
+// Register handles user registration
+func (h *AuthHandler) Register(c *gin.Context) {
+	var req RegisterRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apperrors.AbortWithError(c, apperrors.NewValidationError("Invalid request data", err))
+		return
+	}
+
+	var existing models.User
+	if err := h.db.Where("email = ? OR username = ? OR stellar_address = ?",
+		req.Email, req.Username, req.StellarAddress).First(&existing).Error; err == nil {
+		apperrors.AbortWithError(c, apperrors.NewConflictError("User already exists with this email, username, or Stellar address"))
+		return
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), h.config.BcryptCost)
+	if err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to hash password"))
+		return
+	}
+
+	emailToken := generateSecureToken()
+	user := models.User{
+		StellarAddress:    req.StellarAddress,
+		Email:             req.Email,
+		Username:          req.Username,
+		PasswordHash:      string(hashedPassword),
+		Role:              models.RoleUser,
+		EmailVerified:     false,
+		EmailToken:        emailToken,
+		EmailTokenExpires: time.Now().Add(time.Hour * time.Duration(h.config.EmailTokenHours)),
+	}
+
+	if err := h.db.Create(&user).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to create user"))
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message": "User registered successfully. Please check your email for verification.",
+		"user_id": user.ID,
+	})
+}
+
+// Login handles user authentication
+func (h *AuthHandler) Login(c *gin.Context) {
+	var req LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apperrors.AbortWithError(c, apperrors.NewValidationError("Invalid request data", err))
+		return
+	}
+
+	var user models.User
+	if err := h.db.Where("email = ?", req.Email).First(&user).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid email or password"))
+		return
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
+		apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid email or password"))
+		return
+	}
+
+	if !user.EmailVerified {
+		apperrors.AbortWithError(c, apperrors.NewForbiddenError("Please verify your email before logging in"))
+		return
+	}
+
+	now := time.Now()
+	user.LastLoginAt = &now
+	h.db.Save(&user)
+
+	accessToken, refreshToken, err := h.generateTokens(&user)
+	if err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to generate tokens"))
+		return
+	}
+
+	session := models.UserSession{
+		UserID:       user.ID,
+		SessionToken: generateSecureToken(),
+		IPAddress:    c.ClientIP(),
+		UserAgent:    c.GetHeader("User-Agent"),
+		ExpiresAt:    time.Now().Add(time.Hour * time.Duration(h.config.RefreshTokenHours)),
+	}
+	if err := h.db.Create(&session).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to create session"))
+		return
+	}
+
+	c.JSON(http.StatusOK, TokenResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    int64(h.config.JWTExpirationHours * 3600),
+		User:         toUserInfo(&user),
+	})
+}
+
+// RefreshToken handles token refresh
+func (h *AuthHandler) RefreshToken(c *gin.Context) {
+	var req RefreshTokenRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apperrors.AbortWithError(c, apperrors.NewValidationError("Invalid request data", err))
+		return
+	}
+
+	token, err := jwt.Parse(req.RefreshToken, func(token *jwt.Token) (interface{}, error) {
+		return []byte(h.config.JWTSecret), nil
+	})
+	if err != nil || !token.Valid {
+		apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid refresh token"))
+		return
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid token claims"))
+		return
+	}
+
+	userIDFloat, ok := claims["user_id"].(float64)
+	if !ok {
+		apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid token claims"))
+		return
+	}
+
+	var user models.User
+	if err := h.db.First(&user, uint(userIDFloat)).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("User not found"))
+		return
+	}
+
+	accessToken, refreshToken, err := h.generateTokens(&user)
+	if err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to generate tokens"))
+		return
+	}
+
+	c.JSON(http.StatusOK, TokenResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    int64(h.config.JWTExpirationHours * 3600),
+		User:         toUserInfo(&user),
+	})
+}
+
+// VerifyEmail handles email verification
+func (h *AuthHandler) VerifyEmail(c *gin.Context) {
+	var req VerifyEmailRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apperrors.AbortWithError(c, apperrors.NewValidationError("Invalid request data", err))
+		return
+	}
+
+	var user models.User
+	if err := h.db.Where("email_token = ? AND email_token_expires > ?", req.Token, time.Now()).First(&user).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewBadRequestError("Invalid or expired verification token"))
+		return
+	}
+
+	user.EmailVerified = true
+	user.EmailToken = ""
+	user.EmailTokenExpires = time.Time{}
+	if err := h.db.Save(&user).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to verify email"))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Email verified successfully"})
+}
+
+// ForgotPassword handles forgot password requests
+func (h *AuthHandler) ForgotPassword(c *gin.Context) {
+	var req ForgotPasswordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apperrors.AbortWithError(c, apperrors.NewValidationError("Invalid request data", err))
+		return
+	}
+
+	var user models.User
+	if err := h.db.Where("email = ?", req.Email).First(&user).Error; err != nil {
+		// Don't reveal whether the email exists
+		c.JSON(http.StatusOK, gin.H{"message": "If an account with this email exists, a password reset link has been sent."})
+		return
+	}
+
+	user.PasswordResetToken = generateSecureToken()
+	user.PasswordResetExpires = time.Now().Add(time.Hour * time.Duration(h.config.PasswordResetHours))
+	if err := h.db.Save(&user).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to generate reset token"))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "If an account with this email exists, a password reset link has been sent."})
+}
+
+// ResetPassword handles password reset
+func (h *AuthHandler) ResetPassword(c *gin.Context) {
+	var req ResetPasswordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apperrors.AbortWithError(c, apperrors.NewValidationError("Invalid request data", err))
+		return
+	}
+
+	var user models.User
+	if err := h.db.Where("password_reset_token = ? AND password_reset_expires > ?", req.Token, time.Now()).First(&user).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewBadRequestError("Invalid or expired reset token"))
+		return
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), h.config.BcryptCost)
+	if err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to hash password"))
+		return
+	}
+
+	user.PasswordHash = string(hashedPassword)
+	user.PasswordResetToken = ""
+	user.PasswordResetExpires = time.Time{}
+	if err := h.db.Save(&user).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to reset password"))
+		return
+	}
+
+	// Invalidate all sessions for security
+	h.db.Where("user_id = ?", user.ID).Delete(&models.UserSession{})
+
+	c.JSON(http.StatusOK, gin.H{"message": "Password reset successfully"})
+}
+
+// Logout handles user logout
+func (h *AuthHandler) Logout(c *gin.Context) {
+	userID, exists := c.Get("user_id")
+	if !exists {
+		apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("User not authenticated"))
+		return
+	}
+
+	if err := h.db.Where("user_id = ?", userID).Delete(&models.UserSession{}).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewInternalError("Failed to logout"))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Logged out successfully"})
+}
+
+// GetProfile returns the current user's profile
+func (h *AuthHandler) GetProfile(c *gin.Context) {
+	userID, exists := c.Get("user_id")
+	if !exists {
+		apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("User not authenticated"))
+		return
+	}
+
+	var user models.User
+	if err := h.db.First(&user, userID).Error; err != nil {
+		apperrors.AbortWithError(c, apperrors.NewNotFoundError("User not found"))
+		return
+	}
+
+	c.JSON(http.StatusOK, toUserInfo(&user))
+}
+
+func (h *AuthHandler) generateTokens(user *models.User) (string, string, error) {
+	accessClaims := jwt.MapClaims{
+		"user_id":  user.ID,
+		"email":    user.Email,
+		"username": user.Username,
+		"role":     string(user.Role),
+		"exp":      time.Now().Add(time.Hour * time.Duration(h.config.JWTExpirationHours)).Unix(),
+		"iat":      time.Now().Unix(),
+		"type":     "access",
+		"jti":      uuid.New().String(),
+	}
+	accessToken := jwt.NewWithClaims(jwt.SigningMethodHS256, accessClaims)
+	accessStr, err := accessToken.SignedString([]byte(h.config.JWTSecret))
+	if err != nil {
+		return "", "", err
+	}
+
+	refreshClaims := jwt.MapClaims{
+		"user_id": user.ID,
+		"exp":     time.Now().Add(time.Hour * time.Duration(h.config.RefreshTokenHours)).Unix(),
+		"iat":     time.Now().Unix(),
+		"type":    "refresh",
+		"jti":     uuid.New().String(),
+	}
+	refreshToken := jwt.NewWithClaims(jwt.SigningMethodHS256, refreshClaims)
+	refreshStr, err := refreshToken.SignedString([]byte(h.config.JWTSecret))
+	if err != nil {
+		return "", "", err
+	}
+
+	return accessStr, refreshStr, nil
+}
+
+func generateSecureToken() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func toUserInfo(u *models.User) UserInfo {
+	return UserInfo{
+		ID:             u.ID,
+		StellarAddress: u.StellarAddress,
+		Email:          u.Email,
+		Username:       u.Username,
+		Role:           string(u.Role),
+		EmailVerified:  u.EmailVerified,
+		KYCVerified:    u.KYCVerified,
+		LastLoginAt:    u.LastLoginAt,
+	}
+}

--- a/backend/handlers/auth/auth_test.go
+++ b/backend/handlers/auth/auth_test.go
@@ -1,0 +1,268 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"github.com/yourusername/kor-assetforge/models"
+)
+
+func openTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "host=localhost user=postgres password=password dbname=assetforge_test port=5432 sslmode=disable"
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Skipf("test database not available: %v", err)
+	}
+	return db
+}
+
+type AuthTestSuite struct {
+	suite.Suite
+	db      *gorm.DB
+	handler *AuthHandler
+	router  *gin.Engine
+	config  *AuthConfig
+}
+
+func (suite *AuthTestSuite) SetupSuite() {
+	db := openTestDB(suite.T())
+
+	if err := db.AutoMigrate(&models.User{}, &models.UserSession{}); err != nil {
+		suite.T().Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	config := &AuthConfig{
+		JWTSecret:          "test-secret-key",
+		JWTExpirationHours: 24,
+		RefreshTokenHours:  168,
+		EmailTokenHours:    24,
+		PasswordResetHours: 1,
+		BcryptCost:         4,
+	}
+
+	handler := NewAuthHandler(db, config)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	authMiddleware := NewAuthMiddleware(config.JWTSecret)
+
+	v1 := router.Group("/api/v1")
+	authGroup := v1.Group("/auth")
+	{
+		authGroup.POST("/register", handler.Register)
+		authGroup.POST("/login", handler.Login)
+		authGroup.POST("/refresh", handler.RefreshToken)
+		authGroup.POST("/verify-email", handler.VerifyEmail)
+		authGroup.POST("/forgot-password", handler.ForgotPassword)
+		authGroup.POST("/reset-password", handler.ResetPassword)
+	}
+	protected := v1.Group("")
+	protected.Use(authMiddleware.JWTAuth())
+	{
+		protected.GET("/profile", handler.GetProfile)
+		protected.POST("/logout", handler.Logout)
+	}
+
+	suite.db = db
+	suite.handler = handler
+	suite.router = router
+	suite.config = config
+}
+
+func (suite *AuthTestSuite) TearDownSuite() {
+	suite.db.Exec("DELETE FROM user_sessions")
+	suite.db.Exec("DELETE FROM users")
+	sqlDB, _ := suite.db.DB()
+	sqlDB.Close()
+}
+
+func (suite *AuthTestSuite) newRequest(method, path string, body interface{}) *http.Request {
+	var buf bytes.Buffer
+	if body != nil {
+		json.NewEncoder(&buf).Encode(body)
+	}
+	r := httptest.NewRequest(method, path, &buf)
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func (suite *AuthTestSuite) TestRegister() {
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, suite.newRequest("POST", "/api/v1/auth/register", RegisterRequest{
+		StellarAddress: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+		Email:          "register@example.com",
+		Username:       "registeruser",
+		Password:       "password123",
+	}))
+
+	assert.Equal(suite.T(), http.StatusCreated, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Contains(suite.T(), resp, "message")
+	assert.Contains(suite.T(), resp, "user_id")
+}
+
+func (suite *AuthTestSuite) TestRegisterDuplicateEmail() {
+	suite.db.Create(&models.User{
+		StellarAddress: "GBVNQGYOZQMXKSLGDSFWQ6TYU4KVWLTJJFC7MGXUA74P7UJVSGZ1234",
+		Email:          "duplicate@example.com",
+		Username:       "duplicateuser",
+		PasswordHash:   "hash",
+		EmailVerified:  true,
+	})
+
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, suite.newRequest("POST", "/api/v1/auth/register", RegisterRequest{
+		StellarAddress: "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ",
+		Email:          "duplicate@example.com",
+		Username:       "anotheruser",
+		Password:       "password123",
+	}))
+	assert.Equal(suite.T(), http.StatusConflict, w.Code)
+}
+
+func (suite *AuthTestSuite) TestLogin() {
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("password123"), suite.config.BcryptCost)
+	user := models.User{
+		StellarAddress: "GCKIQYPTHQBE2B5NYNXCMVWI6WDXIJM46TIQO7OO4XJWNVQNQMM1234",
+		Email:          "logintest@example.com",
+		Username:       "logintest",
+		PasswordHash:   string(hashed),
+		EmailVerified:  true,
+	}
+	suite.db.Create(&user)
+
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, suite.newRequest("POST", "/api/v1/auth/login", LoginRequest{
+		Email:    "logintest@example.com",
+		Password: "password123",
+	}))
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var resp TokenResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NotEmpty(suite.T(), resp.AccessToken)
+	assert.NotEmpty(suite.T(), resp.RefreshToken)
+	assert.Equal(suite.T(), "Bearer", resp.TokenType)
+}
+
+func (suite *AuthTestSuite) TestLoginUnverifiedEmail() {
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("password123"), suite.config.BcryptCost)
+	suite.db.Create(&models.User{
+		StellarAddress: "GCYXCGHQMX8SLGDSFWQ6TYU4KVWLTJJFC7MGXUA74P7UJVSGZ1234AB",
+		Email:          "unverified@example.com",
+		Username:       "unverifiedtest",
+		PasswordHash:   string(hashed),
+		EmailVerified:  false,
+	})
+
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, suite.newRequest("POST", "/api/v1/auth/login", LoginRequest{
+		Email:    "unverified@example.com",
+		Password: "password123",
+	}))
+	assert.Equal(suite.T(), http.StatusForbidden, w.Code)
+}
+
+func (suite *AuthTestSuite) TestGetProfile() {
+	user := models.User{
+		StellarAddress: "GDPROFILETEST7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74AB",
+		Email:          "profile@example.com",
+		Username:       "profiletest",
+		PasswordHash:   "hash",
+		Role:           models.RoleUser,
+		EmailVerified:  true,
+		KYCVerified:    true,
+	}
+	suite.db.Create(&user)
+
+	token, _, _ := suite.handler.generateTokens(&user)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/profile", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	suite.router.ServeHTTP(w, r)
+
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+	var resp UserInfo
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(suite.T(), "profiletest", resp.Username)
+	assert.True(suite.T(), resp.KYCVerified)
+}
+
+func (suite *AuthTestSuite) TestVerifyEmail() {
+	token := generateSecureToken()
+	suite.db.Create(&models.User{
+		StellarAddress:    "GDEMAILVERIFY7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74AB",
+		Email:             "verifyemail@example.com",
+		Username:          "verifyemailtest",
+		PasswordHash:      "hash",
+		EmailToken:        token,
+		EmailTokenExpires: time.Now().Add(time.Hour),
+	})
+
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, suite.newRequest("POST", "/api/v1/auth/verify-email", VerifyEmailRequest{Token: token}))
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+}
+
+func (suite *AuthTestSuite) TestForgotPassword() {
+	suite.db.Create(&models.User{
+		StellarAddress: "GDFORGOTPWD7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74AB1",
+		Email:          "forgot@example.com",
+		Username:       "forgottest",
+		PasswordHash:   "hash",
+		EmailVerified:  true,
+	})
+
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, suite.newRequest("POST", "/api/v1/auth/forgot-password", ForgotPasswordRequest{Email: "forgot@example.com"}))
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+}
+
+func (suite *AuthTestSuite) TestResetPassword() {
+	resetToken := generateSecureToken()
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("oldpass123"), suite.config.BcryptCost)
+	user := models.User{
+		StellarAddress:      "GDRESETPWD17SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74AB1",
+		Email:               "resetpwd@example.com",
+		Username:            "resetpwdtest",
+		PasswordHash:        string(hashed),
+		EmailVerified:       true,
+		PasswordResetToken:  resetToken,
+		PasswordResetExpires: time.Now().Add(time.Hour),
+	}
+	suite.db.Create(&user)
+
+	w := httptest.NewRecorder()
+	suite.router.ServeHTTP(w, suite.newRequest("POST", "/api/v1/auth/reset-password", ResetPasswordRequest{
+		Token:    resetToken,
+		Password: "newpassword123",
+	}))
+	assert.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var updated models.User
+	suite.db.First(&updated, user.ID)
+	assert.Empty(suite.T(), updated.PasswordResetToken)
+	assert.NoError(suite.T(), bcrypt.CompareHashAndPassword([]byte(updated.PasswordHash), []byte("newpassword123")))
+}
+
+func TestAuthTestSuite(t *testing.T) {
+	suite.Run(t, new(AuthTestSuite))
+}

--- a/backend/handlers/auth/middleware.go
+++ b/backend/handlers/auth/middleware.go
@@ -1,0 +1,171 @@
+package auth
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/yourusername/kor-assetforge/apperrors"
+	"github.com/yourusername/kor-assetforge/models"
+)
+
+// AuthMiddleware handles JWT authentication and authorization
+type AuthMiddleware struct {
+	jwtSecret string
+}
+
+// NewAuthMiddleware creates a new auth middleware
+func NewAuthMiddleware(jwtSecret string) *AuthMiddleware {
+	return &AuthMiddleware{jwtSecret: jwtSecret}
+}
+
+// JWTAuth middleware validates JWT access tokens
+func (m *AuthMiddleware) JWTAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Authorization header required"))
+			return
+		}
+
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || parts[0] != "Bearer" {
+			apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid authorization header format"))
+			return
+		}
+
+		token, err := jwt.Parse(parts[1], func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, apperrors.NewUnauthorizedError("Invalid signing method")
+			}
+			return []byte(m.jwtSecret), nil
+		})
+		if err != nil || !token.Valid {
+			apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid token"))
+			return
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid token claims"))
+			return
+		}
+
+		if tokenType, _ := claims["type"].(string); tokenType != "access" {
+			apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid token type"))
+			return
+		}
+
+		userIDFloat, ok := claims["user_id"].(float64)
+		if !ok {
+			apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("Invalid user ID in token"))
+			return
+		}
+
+		c.Set("user_id", uint(userIDFloat))
+		c.Set("email", claims["email"])
+		c.Set("username", claims["username"])
+		c.Set("role", claims["role"])
+		c.Next()
+	}
+}
+
+// RequireRole middleware checks if user has the required role level
+func (m *AuthMiddleware) RequireRole(requiredRole models.UserRole) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		role, exists := c.Get("role")
+		if !exists {
+			apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("User role not found"))
+			return
+		}
+
+		if !hasRequiredRole(models.UserRole(role.(string)), requiredRole) {
+			apperrors.AbortWithError(c, apperrors.NewForbiddenError("Insufficient permissions"))
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// RequireRoles middleware accepts any of the given roles
+func (m *AuthMiddleware) RequireRoles(requiredRoles ...models.UserRole) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		role, exists := c.Get("role")
+		if !exists {
+			apperrors.AbortWithError(c, apperrors.NewUnauthorizedError("User role not found"))
+			return
+		}
+
+		userRole := models.UserRole(role.(string))
+		for _, r := range requiredRoles {
+			if hasRequiredRole(userRole, r) {
+				c.Next()
+				return
+			}
+		}
+
+		apperrors.AbortWithError(c, apperrors.NewForbiddenError("Insufficient permissions"))
+	}
+}
+
+// OptionalAuth sets user context if a valid token is present, but does not require it
+func (m *AuthMiddleware) OptionalAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.Next()
+			return
+		}
+
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || parts[0] != "Bearer" {
+			c.Next()
+			return
+		}
+
+		token, err := jwt.Parse(parts[1], func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, nil
+			}
+			return []byte(m.jwtSecret), nil
+		})
+		if err != nil || !token.Valid {
+			c.Next()
+			return
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			c.Next()
+			return
+		}
+
+		if tokenType, _ := claims["type"].(string); tokenType != "access" {
+			c.Next()
+			return
+		}
+
+		if userIDFloat, ok := claims["user_id"].(float64); ok {
+			c.Set("user_id", uint(userIDFloat))
+			c.Set("email", claims["email"])
+			c.Set("username", claims["username"])
+			c.Set("role", claims["role"])
+			c.Set("authenticated", true)
+		}
+
+		c.Next()
+	}
+}
+
+// roleLevel maps roles to numeric levels for hierarchy checks
+var roleLevel = map[models.UserRole]int{
+	models.RoleUser:      1,
+	models.RoleModerator: 2,
+	models.RoleAdmin:     3,
+}
+
+func hasRequiredRole(userRole, requiredRole models.UserRole) bool {
+	return roleLevel[userRole] >= roleLevel[requiredRole]
+}

--- a/backend/handlers/auth/ratelimit.go
+++ b/backend/handlers/auth/ratelimit.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+
+	"github.com/yourusername/kor-assetforge/apperrors"
+)
+
+// AuthRateLimiter manages per-IP rate limiters for auth endpoints
+type AuthRateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*rate.Limiter
+	r        rate.Limit
+	burst    int
+}
+
+// NewAuthRateLimiter creates a new auth rate limiter
+func NewAuthRateLimiter(r rate.Limit, burst int) *AuthRateLimiter {
+	return &AuthRateLimiter{
+		limiters: make(map[string]*rate.Limiter),
+		r:        r,
+		burst:    burst,
+	}
+}
+
+func (rl *AuthRateLimiter) getLimiter(key string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	l, ok := rl.limiters[key]
+	if !ok {
+		l = rate.NewLimiter(rl.r, rl.burst)
+		rl.limiters[key] = l
+	}
+	return l
+}
+
+func (rl *AuthRateLimiter) limit(prefix string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !rl.getLimiter(prefix+":"+c.ClientIP()).Allow() {
+			apperrors.AbortWithError(c, apperrors.NewTooManyRequestsError("Too many requests. Please try again later."))
+			return
+		}
+		c.Next()
+	}
+}
+
+// GeneralAuthRateLimit applies to all auth endpoints
+func (rl *AuthRateLimiter) GeneralAuthRateLimit() gin.HandlerFunc {
+	return rl.limit("auth")
+}
+
+// LoginRateLimit limits login attempts per IP
+func (rl *AuthRateLimiter) LoginRateLimit() gin.HandlerFunc {
+	return rl.limit("login")
+}
+
+// RegisterRateLimit limits registration attempts per IP
+func (rl *AuthRateLimiter) RegisterRateLimit() gin.HandlerFunc {
+	return rl.limit("register")
+}
+
+// PasswordResetRateLimit limits password reset attempts per IP
+func (rl *AuthRateLimiter) PasswordResetRateLimit() gin.HandlerFunc {
+	return rl.limit("password_reset")
+}
+
+// EmailVerificationRateLimit limits email verification attempts per IP
+func (rl *AuthRateLimiter) EmailVerificationRateLimit() gin.HandlerFunc {
+	return rl.limit("email_verify")
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -12,10 +13,13 @@ import (
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/ulule/limiter/v3"
+	"golang.org/x/time/rate"
 	_ "github.com/yourusername/kor-assetforge/docs"
 	"github.com/yourusername/kor-assetforge/config"
 	"github.com/yourusername/kor-assetforge/handlers"
+	"github.com/yourusername/kor-assetforge/handlers/auth"
 	"github.com/yourusername/kor-assetforge/middleware"
+	"github.com/yourusername/kor-assetforge/models"
 	"github.com/yourusername/kor-assetforge/services"
 	"github.com/yourusername/kor-assetforge/utils"
 	"github.com/yourusername/kor-assetforge/validator"
@@ -68,7 +72,8 @@ func main() {
 
 	// Warm common cache entries on startup
 	go cacheManager.Warm(context.Background(), config.WarmCacheEntries(db))
-	// Initialize Rate Limiter (e.g., 100 requests per minute)
+
+	// Initialize Redis-backed rate limiter (optional)
 	var rateLimiterMiddleware gin.HandlerFunc
 	if redisClient != nil {
 		rl, err := handlers.NewRateLimiter(redisClient, limiter.Rate{
@@ -81,6 +86,20 @@ func main() {
 			rateLimiterMiddleware = rl.Middleware()
 		}
 	}
+	_ = rateLimiterMiddleware // available for use on individual routes if needed
+
+	// Setup authentication
+	authConfig := &auth.AuthConfig{
+		JWTSecret:          getEnvOrDefault("JWT_SECRET", "your-super-secret-jwt-key-change-in-production"),
+		JWTExpirationHours: getEnvIntOrDefault("JWT_EXPIRATION_HOURS", 24),
+		RefreshTokenHours:  getEnvIntOrDefault("REFRESH_TOKEN_HOURS", 168),
+		EmailTokenHours:    getEnvIntOrDefault("EMAIL_TOKEN_HOURS", 24),
+		PasswordResetHours: getEnvIntOrDefault("PASSWORD_RESET_HOURS", 1),
+		BcryptCost:         getEnvIntOrDefault("BCRYPT_COST", 12),
+	}
+	authHandler := auth.NewAuthHandler(db, authConfig)
+	authMiddleware := auth.NewAuthMiddleware(authConfig.JWTSecret)
+	authRateLimiter := auth.NewAuthRateLimiter(rate.Limit(5.0/60.0), 10)
 
 	// Setup router
 	router := gin.New()
@@ -123,8 +142,34 @@ func main() {
 	// API v1 routes
 	v1 := router.Group("/api/v1")
 	{
+		// Authentication routes (public)
+		authGroup := v1.Group("/auth")
+		authGroup.Use(authRateLimiter.GeneralAuthRateLimit())
+		{
+			authGroup.POST("/register", authRateLimiter.RegisterRateLimit(), authHandler.Register)
+			authGroup.POST("/login", authRateLimiter.LoginRateLimit(), authHandler.Login)
+			authGroup.POST("/refresh", authHandler.RefreshToken)
+			authGroup.POST("/verify-email", authRateLimiter.EmailVerificationRateLimit(), authHandler.VerifyEmail)
+			authGroup.POST("/forgot-password", authRateLimiter.PasswordResetRateLimit(), authHandler.ForgotPassword)
+			authGroup.POST("/reset-password", authHandler.ResetPassword)
+		}
+
+		// Protected user routes
+		protected := v1.Group("")
+		protected.Use(authMiddleware.JWTAuth())
+		{
+			protected.GET("/profile", authHandler.GetProfile)
+			protected.POST("/logout", authHandler.Logout)
+
+			// Admin-only routes
+			admin := protected.Group("")
+			admin.Use(authMiddleware.RequireRole(models.RoleAdmin))
+			{
+				_ = admin // placeholder until admin routes are added
+			}
+		}
+
 		// Asset routes (with write-through cache invalidation)
-		// Asset routes
 		assetHandler := handlers.NewAssetHandler(db, stellarClient, redisClient)
 		v1.POST("/assets/tokenize",
 			middleware.InvalidateOnWrite(cacheManager, "kor:asset:*"),
@@ -190,4 +235,20 @@ func main() {
 	if err := router.Run(":" + port); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
+}
+
+func getEnvOrDefault(key, defaultValue string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultValue
+}
+
+func getEnvIntOrDefault(key string, defaultValue int) int {
+	if v := os.Getenv(key); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
+	}
+	return defaultValue
 }

--- a/backend/migrations/migrator.go
+++ b/backend/migrations/migrator.go
@@ -1,0 +1,283 @@
+package migrations
+
+import (
+	"database/sql"
+	"embed"
+	"fmt"
+	"io/fs"
+	"log"
+	"sort"
+	"strings"
+	"time"
+)
+
+//go:embed sql/*.sql
+var sqlFiles embed.FS
+
+// Migration represents a single migration version
+type Migration struct {
+	Version int
+	Name    string
+	UpSQL   string
+	DownSQL string
+}
+
+// MigrationRecord is the DB row stored in the schema_migrations table
+type MigrationRecord struct {
+	Version   int
+	Name      string
+	AppliedAt time.Time
+}
+
+// Migrator manages schema migrations
+type Migrator struct {
+	db *sql.DB
+}
+
+// New creates a new Migrator
+func New(db *sql.DB) *Migrator {
+	return &Migrator{db: db}
+}
+
+// Init creates the schema_migrations tracking table if it doesn't exist
+func (m *Migrator) Init() error {
+	_, err := m.db.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version   INTEGER PRIMARY KEY,
+			name      TEXT NOT NULL,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`)
+	return err
+}
+
+// Up runs all pending migrations
+func (m *Migrator) Up() error {
+	if err := m.Init(); err != nil {
+		return fmt.Errorf("failed to init migrations table: %w", err)
+	}
+
+	pending, err := m.pending()
+	if err != nil {
+		return err
+	}
+
+	if len(pending) == 0 {
+		log.Println("migrations: nothing to apply")
+		return nil
+	}
+
+	for _, mg := range pending {
+		log.Printf("migrations: applying %04d_%s ...", mg.Version, mg.Name)
+		if err := m.apply(mg); err != nil {
+			return fmt.Errorf("migration %04d_%s failed: %w", mg.Version, mg.Name, err)
+		}
+		log.Printf("migrations: applied  %04d_%s", mg.Version, mg.Name)
+	}
+	return nil
+}
+
+// Down rolls back n migrations (0 = all)
+func (m *Migrator) Down(n int) error {
+	if err := m.Init(); err != nil {
+		return fmt.Errorf("failed to init migrations table: %w", err)
+	}
+
+	applied, err := m.applied()
+	if err != nil {
+		return err
+	}
+	if len(applied) == 0 {
+		log.Println("migrations: nothing to roll back")
+		return nil
+	}
+
+	all, err := m.load()
+	if err != nil {
+		return err
+	}
+	byVersion := make(map[int]Migration, len(all))
+	for _, mg := range all {
+		byVersion[mg.Version] = mg
+	}
+
+	// Roll back in reverse order
+	sort.Slice(applied, func(i, j int) bool { return applied[i].Version > applied[j].Version })
+	if n > 0 && n < len(applied) {
+		applied = applied[:n]
+	}
+
+	for _, rec := range applied {
+		mg, ok := byVersion[rec.Version]
+		if !ok {
+			return fmt.Errorf("no migration file found for version %d", rec.Version)
+		}
+		log.Printf("migrations: rolling back %04d_%s ...", mg.Version, mg.Name)
+		if err := m.rollback(mg); err != nil {
+			return fmt.Errorf("rollback %04d_%s failed: %w", mg.Version, mg.Name, err)
+		}
+		log.Printf("migrations: rolled back %04d_%s", mg.Version, mg.Name)
+	}
+	return nil
+}
+
+// Status prints current migration state
+func (m *Migrator) Status() ([]MigrationRecord, error) {
+	if err := m.Init(); err != nil {
+		return nil, err
+	}
+	return m.applied()
+}
+
+// Version returns the highest applied migration version, or 0 if none
+func (m *Migrator) Version() (int, error) {
+	applied, err := m.applied()
+	if err != nil || len(applied) == 0 {
+		return 0, err
+	}
+	return applied[len(applied)-1].Version, nil
+}
+
+func (m *Migrator) apply(mg Migration) error {
+	tx, err := m.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(mg.UpSQL); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`INSERT INTO schema_migrations (version, name) VALUES ($1, $2)`,
+		mg.Version, mg.Name,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (m *Migrator) rollback(mg Migration) error {
+	tx, err := m.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(mg.DownSQL); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		`DELETE FROM schema_migrations WHERE version = $1`,
+		mg.Version,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (m *Migrator) pending() ([]Migration, error) {
+	all, err := m.load()
+	if err != nil {
+		return nil, err
+	}
+
+	applied, err := m.applied()
+	if err != nil {
+		return nil, err
+	}
+	appliedSet := make(map[int]struct{}, len(applied))
+	for _, rec := range applied {
+		appliedSet[rec.Version] = struct{}{}
+	}
+
+	var pending []Migration
+	for _, mg := range all {
+		if _, done := appliedSet[mg.Version]; !done {
+			pending = append(pending, mg)
+		}
+	}
+	return pending, nil
+}
+
+func (m *Migrator) applied() ([]MigrationRecord, error) {
+	rows, err := m.db.Query(
+		`SELECT version, name, applied_at FROM schema_migrations ORDER BY version ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var records []MigrationRecord
+	for rows.Next() {
+		var r MigrationRecord
+		if err := rows.Scan(&r.Version, &r.Name, &r.AppliedAt); err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}
+
+// load reads all *.up.sql and *.down.sql files from the embedded sql/ directory
+func (m *Migrator) load() ([]Migration, error) {
+	entries, err := fs.ReadDir(sqlFiles, "sql")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read sql directory: %w", err)
+	}
+
+	upFiles := make(map[string]string)
+	downFiles := make(map[string]string)
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		data, err := sqlFiles.ReadFile("sql/" + name)
+		if err != nil {
+			return nil, err
+		}
+		if strings.HasSuffix(name, ".up.sql") {
+			base := strings.TrimSuffix(name, ".up.sql")
+			upFiles[base] = string(data)
+		} else if strings.HasSuffix(name, ".down.sql") {
+			base := strings.TrimSuffix(name, ".down.sql")
+			downFiles[base] = string(data)
+		}
+	}
+
+	var migrations []Migration
+	for base, upSQL := range upFiles {
+		version, migName, err := parseFilename(base)
+		if err != nil {
+			return nil, err
+		}
+		downSQL := downFiles[base]
+		migrations = append(migrations, Migration{
+			Version: version,
+			Name:    migName,
+			UpSQL:   upSQL,
+			DownSQL: downSQL,
+		})
+	}
+
+	sort.Slice(migrations, func(i, j int) bool {
+		return migrations[i].Version < migrations[j].Version
+	})
+	return migrations, nil
+}
+
+// parseFilename extracts version and name from "0001_create_users"
+func parseFilename(base string) (int, string, error) {
+	parts := strings.SplitN(base, "_", 2)
+	if len(parts) != 2 {
+		return 0, "", fmt.Errorf("invalid migration filename: %s", base)
+	}
+	var version int
+	if _, err := fmt.Sscanf(parts[0], "%d", &version); err != nil {
+		return 0, "", fmt.Errorf("invalid version in filename %s: %w", base, err)
+	}
+	return version, parts[1], nil
+}

--- a/backend/migrations/migrator_test.go
+++ b/backend/migrations/migrator_test.go
@@ -1,0 +1,73 @@
+package migrations_test
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/yourusername/kor-assetforge/migrations"
+)
+
+// openTestDB connects to the test database from DATABASE_URL env.
+// If DATABASE_URL is not set the test is skipped.
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := "host=localhost user=postgres password=password dbname=assetforge_test port=5432 sslmode=disable"
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Skipf("cannot open test database: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		t.Skipf("test database not reachable: %v", err)
+	}
+	return db
+}
+
+func TestMigratorUpAndDown(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	m := migrations.New(db)
+
+	// Apply all migrations
+	if err := m.Up(); err != nil {
+		t.Fatalf("Up() error: %v", err)
+	}
+
+	v, err := m.Version()
+	if err != nil {
+		t.Fatalf("Version() error: %v", err)
+	}
+	if v == 0 {
+		t.Fatal("expected version > 0 after Up()")
+	}
+
+	// Roll back all
+	if err := m.Down(0); err != nil {
+		t.Fatalf("Down(0) error: %v", err)
+	}
+
+	v2, err := m.Version()
+	if err != nil {
+		t.Fatalf("Version() after Down error: %v", err)
+	}
+	if v2 != 0 {
+		t.Fatalf("expected version 0 after Down(0), got %d", v2)
+	}
+}
+
+func TestMigratorIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	m := migrations.New(db)
+
+	if err := m.Up(); err != nil {
+		t.Fatalf("first Up() error: %v", err)
+	}
+	// Running Up again should be a no-op
+	if err := m.Up(); err != nil {
+		t.Fatalf("second Up() error: %v", err)
+	}
+}

--- a/backend/migrations/sql/0001_create_users.down.sql
+++ b/backend/migrations/sql/0001_create_users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/backend/migrations/sql/0001_create_users.up.sql
+++ b/backend/migrations/sql/0001_create_users.up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS users (
+    id BIGSERIAL PRIMARY KEY,
+    stellar_address VARCHAR(56) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    username VARCHAR(50) NOT NULL,
+    password_hash TEXT NOT NULL,
+    role VARCHAR(20) NOT NULL DEFAULT 'user',
+    kyc_verified BOOLEAN NOT NULL DEFAULT false,
+    accredited_investor BOOLEAN NOT NULL DEFAULT false,
+    email_verified BOOLEAN NOT NULL DEFAULT false,
+    email_token VARCHAR(64),
+    email_token_expires TIMESTAMPTZ,
+    password_reset_token VARCHAR(64),
+    password_reset_expires TIMESTAMPTZ,
+    last_login_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ,
+    CONSTRAINT uq_users_stellar_address UNIQUE (stellar_address),
+    CONSTRAINT uq_users_email UNIQUE (email),
+    CONSTRAINT uq_users_username UNIQUE (username)
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_email_token ON users (email_token) WHERE email_token IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_users_password_reset_token ON users (password_reset_token) WHERE password_reset_token IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_users_deleted_at ON users (deleted_at);

--- a/backend/migrations/sql/0002_create_assets.down.sql
+++ b/backend/migrations/sql/0002_create_assets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS assets;

--- a/backend/migrations/sql/0002_create_assets.up.sql
+++ b/backend/migrations/sql/0002_create_assets.up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS assets (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    symbol VARCHAR(20) NOT NULL,
+    asset_type VARCHAR(50) NOT NULL,
+    total_supply BIGINT NOT NULL DEFAULT 0,
+    fractions BIGINT NOT NULL DEFAULT 1,
+    contract_id VARCHAR(255),
+    owner_address VARCHAR(56) NOT NULL,
+    metadata TEXT,
+    image_url TEXT,
+    document_url TEXT,
+    verified BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_assets_symbol ON assets (symbol);
+CREATE INDEX IF NOT EXISTS idx_assets_owner_address ON assets (owner_address);
+CREATE INDEX IF NOT EXISTS idx_assets_asset_type ON assets (asset_type);
+CREATE INDEX IF NOT EXISTS idx_assets_verified ON assets (verified);
+CREATE INDEX IF NOT EXISTS idx_assets_created_at ON assets (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_assets_deleted_at ON assets (deleted_at);

--- a/backend/migrations/sql/0003_create_listings_and_transactions.down.sql
+++ b/backend/migrations/sql/0003_create_listings_and_transactions.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS listings;

--- a/backend/migrations/sql/0003_create_listings_and_transactions.up.sql
+++ b/backend/migrations/sql/0003_create_listings_and_transactions.up.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS listings (
+    id BIGSERIAL PRIMARY KEY,
+    asset_id BIGINT NOT NULL REFERENCES assets(id),
+    amount BIGINT NOT NULL,
+    price_per_unit NUMERIC(20, 8) NOT NULL,
+    seller_addr VARCHAR(56) NOT NULL,
+    listing_id VARCHAR(255),
+    active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_listings_asset_id ON listings (asset_id);
+CREATE INDEX IF NOT EXISTS idx_listings_seller_addr ON listings (seller_addr);
+CREATE INDEX IF NOT EXISTS idx_listings_active ON listings (active);
+CREATE INDEX IF NOT EXISTS idx_listings_deleted_at ON listings (deleted_at);
+
+CREATE TABLE IF NOT EXISTS transactions (
+    id BIGSERIAL PRIMARY KEY,
+    asset_id BIGINT NOT NULL REFERENCES assets(id),
+    amount BIGINT NOT NULL,
+    from_address VARCHAR(56) NOT NULL,
+    to_address VARCHAR(56) NOT NULL,
+    tx_hash VARCHAR(255),
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_asset_id ON transactions (asset_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_from_address ON transactions (from_address);
+CREATE INDEX IF NOT EXISTS idx_transactions_to_address ON transactions (to_address);
+CREATE INDEX IF NOT EXISTS idx_transactions_status ON transactions (status);
+CREATE INDEX IF NOT EXISTS idx_transactions_created_at ON transactions (created_at DESC);

--- a/backend/migrations/sql/0004_create_user_balances_and_sessions.down.sql
+++ b/backend/migrations/sql/0004_create_user_balances_and_sessions.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS user_sessions;
+DROP TABLE IF EXISTS user_balances;

--- a/backend/migrations/sql/0004_create_user_balances_and_sessions.up.sql
+++ b/backend/migrations/sql/0004_create_user_balances_and_sessions.up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS user_balances (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    asset_id BIGINT NOT NULL REFERENCES assets(id),
+    balance BIGINT NOT NULL DEFAULT 0,
+    locked_balance BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_user_balances_user_asset UNIQUE (user_id, asset_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_balances_user_id ON user_balances (user_id);
+CREATE INDEX IF NOT EXISTS idx_user_balances_asset_id ON user_balances (asset_id);
+
+CREATE TABLE IF NOT EXISTS user_sessions (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    session_token VARCHAR(64) NOT NULL,
+    ip_address VARCHAR(45),
+    user_agent TEXT,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_user_sessions_token UNIQUE (session_token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id ON user_sessions (user_id);
+CREATE INDEX IF NOT EXISTS idx_user_sessions_expires_at ON user_sessions (expires_at);

--- a/backend/migrations/sql/0005_create_kyc_tables.down.sql
+++ b/backend/migrations/sql/0005_create_kyc_tables.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS compliance_audit_logs;
+DROP TABLE IF EXISTS aml_screenings;
+DROP TABLE IF EXISTS kyc_documents;
+DROP TABLE IF EXISTS kyc_records;

--- a/backend/migrations/sql/0005_create_kyc_tables.up.sql
+++ b/backend/migrations/sql/0005_create_kyc_tables.up.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS kyc_records (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    provider_record_id VARCHAR(255),
+    full_name VARCHAR(255) NOT NULL,
+    date_of_birth DATE NOT NULL,
+    nationality VARCHAR(100) NOT NULL,
+    document_type VARCHAR(50) NOT NULL,
+    document_number_hash VARCHAR(64) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    risk_score INTEGER NOT NULL DEFAULT 0,
+    aml_cleared BOOLEAN NOT NULL DEFAULT false,
+    accredited_investor BOOLEAN NOT NULL DEFAULT false,
+    review_notes TEXT,
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_kyc_records_user_id ON kyc_records (user_id);
+CREATE INDEX IF NOT EXISTS idx_kyc_records_status ON kyc_records (status);
+CREATE INDEX IF NOT EXISTS idx_kyc_records_deleted_at ON kyc_records (deleted_at);
+
+CREATE TABLE IF NOT EXISTS kyc_documents (
+    id BIGSERIAL PRIMARY KEY,
+    kyc_record_id BIGINT NOT NULL REFERENCES kyc_records(id),
+    document_type VARCHAR(50) NOT NULL,
+    file_name VARCHAR(255) NOT NULL,
+    file_hash VARCHAR(64) NOT NULL,
+    storage_path TEXT NOT NULL,
+    mime_type VARCHAR(100) NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_kyc_documents_kyc_record_id ON kyc_documents (kyc_record_id);
+
+CREATE TABLE IF NOT EXISTS aml_screenings (
+    id BIGSERIAL PRIMARY KEY,
+    kyc_record_id BIGINT NOT NULL REFERENCES kyc_records(id),
+    screening_id VARCHAR(255) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    risk_level VARCHAR(20) NOT NULL DEFAULT 'low',
+    matches JSONB,
+    screened_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_aml_screenings_kyc_record_id ON aml_screenings (kyc_record_id);
+
+CREATE TABLE IF NOT EXISTS compliance_audit_logs (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    action VARCHAR(100) NOT NULL,
+    entity_type VARCHAR(50) NOT NULL,
+    entity_id VARCHAR(255) NOT NULL,
+    details TEXT,
+    ip_address VARCHAR(45),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_audit_logs_user_id ON compliance_audit_logs (user_id);
+CREATE INDEX IF NOT EXISTS idx_compliance_audit_logs_created_at ON compliance_audit_logs (created_at DESC);

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -6,28 +6,56 @@ import (
 	"gorm.io/gorm"
 )
 
+// UserRole represents user roles for RBAC
+type UserRole string
+
+const (
+	RoleUser      UserRole = "user"
+	RoleAdmin     UserRole = "admin"
+	RoleModerator UserRole = "moderator"
+)
+
 // User represents a platform user
 type User struct {
-	ID              uint           `gorm:"primaryKey" json:"id"`
-	StellarAddress  string         `gorm:"uniqueIndex;not null" json:"stellar_address"`
-	Email           string         `gorm:"uniqueIndex" json:"email"`
-	Username        string         `gorm:"uniqueIndex" json:"username"`
-	Role            string         `gorm:"default:'user'" json:"role"` // 'user' or 'admin'
-	KYCVerified     bool           `gorm:"default:false" json:"kyc_verified"`
-	AccreditedInvestor bool        `gorm:"default:false" json:"accredited_investor"`
-	CreatedAt       time.Time      `json:"created_at"`
-	UpdatedAt       time.Time      `json:"updated_at"`
-	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`
+	ID                   uint           `gorm:"primaryKey" json:"id"`
+	StellarAddress       string         `gorm:"uniqueIndex;not null" json:"stellar_address"`
+	Email                string         `gorm:"uniqueIndex" json:"email"`
+	Username             string         `gorm:"uniqueIndex" json:"username"`
+	PasswordHash         string         `gorm:"not null" json:"-"`
+	Role                 UserRole       `gorm:"default:'user'" json:"role"`
+	KYCVerified          bool           `gorm:"default:false" json:"kyc_verified"`
+	AccreditedInvestor   bool           `gorm:"default:false" json:"accredited_investor"`
+	EmailVerified        bool           `gorm:"default:false" json:"email_verified"`
+	EmailToken           string         `gorm:"index" json:"-"`
+	EmailTokenExpires    time.Time      `json:"-"`
+	PasswordResetToken   string         `gorm:"index" json:"-"`
+	PasswordResetExpires time.Time      `json:"-"`
+	LastLoginAt          *time.Time     `json:"last_login_at,omitempty"`
+	CreatedAt            time.Time      `json:"created_at"`
+	UpdatedAt            time.Time      `json:"updated_at"`
+	DeletedAt            gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+// UserSession tracks active login sessions
+type UserSession struct {
+	ID           uint      `gorm:"primaryKey" json:"id"`
+	UserID       uint      `gorm:"not null;index" json:"user_id"`
+	User         User      `gorm:"foreignKey:UserID" json:"-"`
+	SessionToken string    `gorm:"uniqueIndex;not null" json:"-"`
+	IPAddress    string    `json:"ip_address"`
+	UserAgent    string    `json:"user_agent"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	CreatedAt    time.Time `json:"created_at"`
 }
 
 // UserBalance represents a user's token balance
 type UserBalance struct {
-	ID             uint      `gorm:"primaryKey" json:"id"`
-	UserID         uint      `gorm:"not null" json:"user_id"`
-	User           User      `gorm:"foreignKey:UserID" json:"user,omitempty"`
-	AssetID        uint      `gorm:"not null" json:"asset_id"`
-	Asset          Asset     `gorm:"foreignKey:AssetID" json:"asset,omitempty"`
-	Balance        int64     `gorm:"not null;default:0" json:"balance"`
-	LockedBalance  int64     `gorm:"not null;default:0" json:"locked_balance"` // For active listings
-	UpdatedAt      time.Time `json:"updated_at"`
+	ID            uint      `gorm:"primaryKey" json:"id"`
+	UserID        uint      `gorm:"not null" json:"user_id"`
+	User          User      `gorm:"foreignKey:UserID" json:"user,omitempty"`
+	AssetID       uint      `gorm:"not null" json:"asset_id"`
+	Asset         Asset     `gorm:"foreignKey:AssetID" json:"asset,omitempty"`
+	Balance       int64     `gorm:"not null;default:0" json:"balance"`
+	LockedBalance int64     `gorm:"not null;default:0" json:"locked_balance"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary

## Issue #44 — Authentication & Authorization

- `handlers/auth/auth.go` — Register, Login, Logout, RefreshToken, VerifyEmail, ForgotPassword, ResetPassword handlers
- `handlers/auth/middleware.go` — `JWTAuth()`, `RequireRole()`, `RequireRoles()`, `OptionalAuth()` middleware
- `handlers/auth/ratelimit.go` — Per-IP token-bucket rate limiting for every auth endpoint
- `models/user.go` — Added `UserRole` type, auth fields (`PasswordHash`, `EmailVerified`, `EmailToken`, `PasswordResetToken`, `LastLoginAt`) and `UserSession` model
- `apperrors/errors.go` — Added `Forbidden`, `Conflict`, `TooManyRequests` error codes and helper constructors
- `main.go` — Auth routes wired under `/api/v1/auth/*`; `/api/v1/profile` and `/api/v1/logout` protected by `JWTAuth`

## Issue #47 — Database Migration System

- `migrations/migrator.go` — Pure-Go migrator using `embed.FS`; supports `Up`, `Down(n)`, `Status`, `Version`; each migration runs in a transaction; tracks applied versions in `schema_migrations` table
- `migrations/sql/000[1-5]_*.{up,down}.sql` — Initial SQL migrations for all core tables (users, assets, listings, transactions, user_balances, user_sessions, KYC tables)
- `cmd/migrate/main.go` — Standalone CLI: `migrate up | down [n] | status | version`
- `config/config.go` — `InitDB` now runs SQL migrations on startup before GORM AutoMigrate

Closes #44
Closes #47