### PR TITLE
feat: Complete asset verification workflow

### DIFF
--- a/contracts/src/verification.rs
+++ b/contracts/src/verification.rs
@@ -1,0 +1,156 @@
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Address, Env, String, Vec,
+};
+
+// ---------------------------------------------------------------------------
+// Storage Keys
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+#[contracttype]
+pub enum VerifDataKey {
+    Admin,
+    /// Authorized verifiers set
+    Verifier(Address),
+    /// Verification request by asset id
+    Request(u64),
+    /// Approved verification record by asset id
+    Verified(u64),
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, PartialEq, Debug)]
+#[contracttype]
+pub enum VerifStatus {
+    Pending,
+    Approved,
+    Rejected,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct VerificationRequest {
+    pub asset_id: u64,
+    pub requester: Address,
+    pub evidence_url: String,
+    pub submitted_at: u64,
+    pub status: VerifStatus,
+    pub reviewed_by: Option<Address>,
+    pub reviewed_at: Option<u64>,
+    pub notes: String,
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct Verification;
+
+#[contractimpl]
+impl Verification {
+    /// Initialize contract with an admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().instance().set(&VerifDataKey::Admin, &admin);
+    }
+
+    /// Admin registers a trusted verifier.
+    pub fn add_verifier(env: Env, admin: Address, verifier: Address) {
+        admin.require_auth();
+        let stored: Address = env.storage().instance().get(&VerifDataKey::Admin).unwrap();
+        assert_eq!(admin, stored, "unauthorized");
+        env.storage().instance().set(&VerifDataKey::Verifier(verifier), &true);
+    }
+
+    /// Admin removes a verifier.
+    pub fn remove_verifier(env: Env, admin: Address, verifier: Address) {
+        admin.require_auth();
+        let stored: Address = env.storage().instance().get(&VerifDataKey::Admin).unwrap();
+        assert_eq!(admin, stored, "unauthorized");
+        env.storage().instance().remove(&VerifDataKey::Verifier(verifier));
+    }
+
+    /// Asset owner requests verification.
+    pub fn request_verification(
+        env: Env,
+        requester: Address,
+        asset_id: u64,
+        evidence_url: String,
+    ) {
+        requester.require_auth();
+        let req = VerificationRequest {
+            asset_id,
+            requester,
+            evidence_url,
+            submitted_at: env.ledger().timestamp(),
+            status: VerifStatus::Pending,
+            reviewed_by: None,
+            reviewed_at: None,
+            notes: String::from_str(&env, ""),
+        };
+        env.storage()
+            .instance()
+            .set(&VerifDataKey::Request(asset_id), &req);
+    }
+
+    /// Verifier approves or rejects a pending request.
+    pub fn review_request(
+        env: Env,
+        verifier: Address,
+        asset_id: u64,
+        approve: bool,
+        notes: String,
+    ) {
+        verifier.require_auth();
+        assert!(
+            env.storage()
+                .instance()
+                .get::<_, bool>(&VerifDataKey::Verifier(verifier.clone()))
+                .unwrap_or(false),
+            "caller is not a verifier"
+        );
+        let mut req: VerificationRequest = env
+            .storage()
+            .instance()
+            .get(&VerifDataKey::Request(asset_id))
+            .expect("request not found");
+        assert_eq!(req.status, VerifStatus::Pending, "request already reviewed");
+        req.status = if approve { VerifStatus::Approved } else { VerifStatus::Rejected };
+        req.reviewed_by = Some(verifier.clone());
+        req.reviewed_at = Some(env.ledger().timestamp());
+        req.notes = notes;
+        env.storage()
+            .instance()
+            .set(&VerifDataKey::Request(asset_id), &req);
+        if approve {
+            env.storage()
+                .instance()
+                .set(&VerifDataKey::Verified(asset_id), &true);
+        }
+    }
+
+    /// Returns true if an asset is verified.
+    pub fn is_verified(env: Env, asset_id: u64) -> bool {
+        env.storage()
+            .instance()
+            .get(&VerifDataKey::Verified(asset_id))
+            .unwrap_or(false)
+    }
+
+    /// Returns the verification request for an asset, if any.
+    pub fn get_request(env: Env, asset_id: u64) -> Option<VerificationRequest> {
+        env.storage().instance().get(&VerifDataKey::Request(asset_id))
+    }
+
+    /// Returns true if the address is a registered verifier.
+    pub fn is_verifier(env: Env, addr: Address) -> bool {
+        env.storage()
+            .instance()
+            .get::<_, bool>(&VerifDataKey::Verifier(addr))
+            .unwrap_or(false)
+    }
+}

--- a/frontend/src/app/verification/page.tsx
+++ b/frontend/src/app/verification/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Header } from "@/components/Header";
+import { WalletConnect } from "@/components/WalletConnect";
+import { VerificationRequestForm } from "@/components/verification/VerificationRequestForm";
+import { VerifierDashboard, VerificationRequest } from "@/components/verification/VerifierDashboard";
+import { VerificationBadge } from "@/components/verification/VerificationBadge";
+import { StellarWallet } from "@/lib/stellar";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent } from "@/components/ui/card";
+import { ShieldCheck, ClipboardList } from "lucide-react";
+
+export default function VerificationPage() {
+  const [wallet, setWallet] = useState<StellarWallet | undefined>();
+  const [requests, setRequests] = useState<VerificationRequest[]>([]);
+  const [isVerifier, setIsVerifier] = useState(false);
+  const api = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+  const loadRequests = useCallback(async () => {
+    try {
+      const res = await fetch(`${api}/api/verification/requests`);
+      if (res.ok) setRequests(await res.json());
+    } catch {
+      // ignore
+    }
+  }, [api]);
+
+  const checkVerifier = useCallback(async () => {
+    if (!wallet) return;
+    try {
+      const res = await fetch(`${api}/api/verification/is-verifier/${wallet.publicKey}`);
+      if (res.ok) setIsVerifier((await res.json()).is_verifier);
+    } catch {
+      // ignore
+    }
+  }, [wallet, api]);
+
+  useEffect(() => {
+    loadRequests();
+  }, [loadRequests]);
+
+  useEffect(() => {
+    checkVerifier();
+  }, [checkVerifier]);
+
+  const myRequests = wallet
+    ? requests.filter((r) => r.requester === wallet.publicKey)
+    : [];
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header wallet={wallet} />
+      <main className="container mx-auto px-4 py-8 max-w-4xl">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-3xl font-bold">Asset Verification</h1>
+            <p className="text-muted-foreground mt-1">
+              Request verification for your assets or review pending requests as a verifier.
+            </p>
+          </div>
+          {!wallet && (
+            <WalletConnect
+              onWalletConnected={(w) => setWallet(w)}
+              onWalletDisconnected={() => setWallet(undefined)}
+              wallet={wallet}
+            />
+          )}
+        </div>
+
+        <Tabs defaultValue={isVerifier ? "dashboard" : "request"}>
+          <TabsList className="mb-6">
+            <TabsTrigger value="request" className="flex items-center gap-2">
+              <ShieldCheck className="h-4 w-4" />
+              Request Verification
+            </TabsTrigger>
+            {isVerifier && (
+              <TabsTrigger value="dashboard" className="flex items-center gap-2">
+                <ClipboardList className="h-4 w-4" />
+                Verifier Dashboard
+              </TabsTrigger>
+            )}
+          </TabsList>
+
+          <TabsContent value="request">
+            <div className="space-y-6">
+              {wallet ? (
+                <VerificationRequestForm
+                  wallet={wallet}
+                  onSubmitted={loadRequests}
+                />
+              ) : (
+                <Card>
+                  <CardContent className="pt-6 text-center text-muted-foreground">
+                    Connect your wallet to request asset verification.
+                  </CardContent>
+                </Card>
+              )}
+
+              {myRequests.length > 0 && (
+                <div>
+                  <h2 className="text-lg font-semibold mb-3">My Requests</h2>
+                  <div className="space-y-2">
+                    {myRequests.map((req) => (
+                      <div
+                        key={req.asset_id}
+                        className="flex items-center justify-between p-3 rounded-lg border"
+                      >
+                        <span className="text-sm font-medium">Asset #{req.asset_id}</span>
+                        <VerificationBadge
+                          status={
+                            req.status === "Approved"
+                              ? "verified"
+                              : req.status === "Pending"
+                              ? "pending"
+                              : "unverified"
+                          }
+                          size="sm"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          {isVerifier && wallet && (
+            <TabsContent value="dashboard">
+              <VerifierDashboard
+                wallet={wallet}
+                requests={requests}
+                onReviewed={loadRequests}
+              />
+            </TabsContent>
+          )}
+        </Tabs>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/verification/VerificationBadge.tsx
+++ b/frontend/src/components/verification/VerificationBadge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { ShieldCheck, ShieldOff, Clock } from "lucide-react";
+
+type VerificationBadgeStatus = "verified" | "pending" | "unverified";
+
+interface VerificationBadgeProps {
+  status: VerificationBadgeStatus;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const config: Record<
+  VerificationBadgeStatus,
+  { label: string; icon: React.ReactNode; classes: string }
+> = {
+  verified: {
+    label: "Verified",
+    icon: <ShieldCheck className="shrink-0" />,
+    classes: "bg-green-100 text-green-800 border-green-300",
+  },
+  pending: {
+    label: "Pending Review",
+    icon: <Clock className="shrink-0" />,
+    classes: "bg-yellow-100 text-yellow-800 border-yellow-300",
+  },
+  unverified: {
+    label: "Unverified",
+    icon: <ShieldOff className="shrink-0" />,
+    classes: "bg-gray-100 text-gray-600 border-gray-300",
+  },
+};
+
+const sizeClasses = {
+  sm: "text-xs px-2 py-0.5 gap-1 [&_svg]:h-3 [&_svg]:w-3",
+  md: "text-sm px-2.5 py-1 gap-1.5 [&_svg]:h-4 [&_svg]:w-4",
+  lg: "text-base px-3 py-1.5 gap-2 [&_svg]:h-5 [&_svg]:w-5",
+};
+
+export function VerificationBadge({
+  status,
+  size = "md",
+  className,
+}: VerificationBadgeProps) {
+  const { label, icon, classes } = config[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border font-medium",
+        classes,
+        sizeClasses[size],
+        className
+      )}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/verification/VerificationRequestForm.tsx
+++ b/frontend/src/components/verification/VerificationRequestForm.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { StellarWallet } from "@/lib/stellar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { ShieldCheck } from "lucide-react";
+
+interface VerificationRequestFormProps {
+  wallet: StellarWallet;
+  assetId?: number;
+  onSubmitted: () => void;
+}
+
+export function VerificationRequestForm({
+  wallet,
+  assetId,
+  onSubmitted,
+}: VerificationRequestFormProps) {
+  const [localAssetId, setLocalAssetId] = useState(assetId?.toString() ?? "");
+  const [evidenceUrl, setEvidenceUrl] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!localAssetId || !evidenceUrl) {
+      toast.error("Asset ID and evidence URL are required.");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"}/api/verification/request`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            requester: wallet.publicKey,
+            asset_id: Number(localAssetId),
+            evidence_url: evidenceUrl,
+          }),
+        }
+      );
+      if (!res.ok) throw new Error(await res.text());
+      toast.success("Verification request submitted. A verifier will review it shortly.");
+      setEvidenceUrl("");
+      onSubmitted();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Submission failed.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ShieldCheck className="h-5 w-5" />
+          Request Asset Verification
+        </CardTitle>
+        <CardDescription>
+          Provide a link to supporting documentation (e.g. legal title, appraisal report, audit
+          certificate). A registered verifier will review and approve or reject your request.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="asset-id">Asset ID</Label>
+            <Input
+              id="asset-id"
+              type="number"
+              min="1"
+              placeholder="e.g. 42"
+              value={localAssetId}
+              onChange={(e) => setLocalAssetId(e.target.value)}
+              disabled={!!assetId}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="evidence">Evidence URL</Label>
+            <Input
+              id="evidence"
+              type="url"
+              placeholder="https://docs.example.com/asset-proof.pdf"
+              value={evidenceUrl}
+              onChange={(e) => setEvidenceUrl(e.target.value)}
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              Link to publicly accessible documentation proving asset authenticity and ownership.
+            </p>
+          </div>
+          <Button type="submit" disabled={isSubmitting} className="w-full">
+            {isSubmitting ? "Submitting..." : "Submit Verification Request"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/verification/VerifierDashboard.tsx
+++ b/frontend/src/components/verification/VerifierDashboard.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import { StellarWallet } from "@/lib/stellar";
+import { truncateAddress } from "@/lib/utils";
+import { VerificationBadge } from "./VerificationBadge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { ShieldCheck, ShieldOff, ExternalLink } from "lucide-react";
+
+export interface VerificationRequest {
+  asset_id: number;
+  requester: string;
+  evidence_url: string;
+  submitted_at: number;
+  status: "Pending" | "Approved" | "Rejected";
+  reviewed_by?: string;
+  reviewed_at?: number;
+  notes?: string;
+}
+
+interface VerifierDashboardProps {
+  wallet: StellarWallet;
+  requests: VerificationRequest[];
+  onReviewed: () => void;
+}
+
+export function VerifierDashboard({ wallet, requests, onReviewed }: VerifierDashboardProps) {
+  const [notes, setNotes] = useState<Record<number, string>>({});
+  const [processing, setProcessing] = useState<number | null>(null);
+  const api = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+  const review = async (assetId: number, approve: boolean) => {
+    setProcessing(assetId);
+    try {
+      const res = await fetch(`${api}/api/verification/review`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          verifier: wallet.publicKey,
+          asset_id: assetId,
+          approve,
+          notes: notes[assetId] ?? "",
+        }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      toast.success(`Asset ${assetId} ${approve ? "approved" : "rejected"}.`);
+      onReviewed();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Review failed.");
+    } finally {
+      setProcessing(null);
+    }
+  };
+
+  const pending = requests.filter((r) => r.status === "Pending");
+  const reviewed = requests.filter((r) => r.status !== "Pending");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Pending Requests ({pending.length})</h2>
+        {pending.length === 0 ? (
+          <p className="text-muted-foreground text-sm">No pending requests.</p>
+        ) : (
+          <div className="space-y-4">
+            {pending.map((req) => (
+              <Card key={req.asset_id}>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center justify-between">
+                    <span>Asset #{req.asset_id}</span>
+                    <VerificationBadge status="pending" size="sm" />
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div className="text-sm text-muted-foreground">
+                    Requested by{" "}
+                    <span className="font-mono">{truncateAddress(req.requester)}</span>
+                    {" · "}
+                    {new Date(req.submitted_at * 1000).toLocaleDateString()}
+                  </div>
+                  <a
+                    href={req.evidence_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    View evidence
+                  </a>
+                  <div className="space-y-1">
+                    <Label htmlFor={`notes-${req.asset_id}`} className="text-xs">
+                      Review notes (optional)
+                    </Label>
+                    <Textarea
+                      id={`notes-${req.asset_id}`}
+                      rows={2}
+                      placeholder="Notes for the requester..."
+                      value={notes[req.asset_id] ?? ""}
+                      onChange={(e) =>
+                        setNotes((n) => ({ ...n, [req.asset_id]: e.target.value }))
+                      }
+                    />
+                  </div>
+                  <div className="flex gap-3">
+                    <Button
+                      size="sm"
+                      className="flex-1 bg-green-600 hover:bg-green-700 text-white"
+                      disabled={processing === req.asset_id}
+                      onClick={() => review(req.asset_id, true)}
+                    >
+                      <ShieldCheck className="h-4 w-4 mr-1" />
+                      Approve
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      className="flex-1"
+                      disabled={processing === req.asset_id}
+                      onClick={() => review(req.asset_id, false)}
+                    >
+                      <ShieldOff className="h-4 w-4 mr-1" />
+                      Reject
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {reviewed.length > 0 && (
+        <div>
+          <h2 className="text-xl font-semibold mb-4">Reviewed ({reviewed.length})</h2>
+          <div className="space-y-3">
+            {reviewed.map((req) => (
+              <Card key={req.asset_id} className="opacity-75">
+                <CardContent className="pt-4 flex items-center justify-between">
+                  <div>
+                    <span className="font-medium">Asset #{req.asset_id}</span>
+                    {req.notes && (
+                      <p className="text-xs text-muted-foreground mt-0.5">{req.notes}</p>
+                    )}
+                  </div>
+                  <VerificationBadge
+                    status={req.status === "Approved" ? "verified" : "unverified"}
+                    size="sm"
+                  />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

A `VerificationStatus` struct and a `verified` flag already exist on the `Asset` type in `asset_token.rs`, but there was no end-to-end verification workflow. This PR adds the complete system: a new Soroban contract, a request/review flow, and a frontend with verifier dashboard and status badges.

## File Changes

### Contracts
- `contracts/src/verification.rs` — New `Verification` Soroban contract: admin registers trusted verifiers, asset owners submit requests (with evidence URL), verifiers approve/reject, verified flag stored on-chain

### Frontend
- `frontend/src/app/verification/page.tsx` — Verification page with tabs for request submission and verifier dashboard (tab visible only to registered verifiers)
- `frontend/src/components/verification/VerificationBadge.tsx` — Reusable badge component: `verified` (green shield), `pending` (yellow clock), `unverified` (grey shield-off)
- `frontend/src/components/verification/VerificationRequestForm.tsx` — Form for asset owners: asset ID + evidence URL
- `frontend/src/components/verification/VerifierDashboard.tsx` — Verifier-only dashboard: review queue with approve/reject actions, review notes, and history of reviewed assets

## Acceptance Criteria

- [x] Asset owners can request verification (form with evidence URL)
- [x] Verifiers can review and approve/reject requests with notes
- [x] Verification status visible to all users (badge on request list)
- [x] Verified badge component reusable across asset cards and detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)