### PR TITLE
feat: Liquidity fee tiers, flash loan protection & governance templates

### DIFF
--- a/contracts/src/dispute_resolution.rs
+++ b/contracts/src/dispute_resolution.rs
@@ -375,6 +375,7 @@ impl DisputeResolution {
             DisputeOutcome::BuyerFavor => summary.buyer_favor += 1,
             DisputeOutcome::SellerFavor => summary.seller_favor += 1,
             DisputeOutcome::Split => summary.split += 1,
+            DisputeOutcome::None => panic!("invalid vote outcome"),
         }
 
         env.storage()
@@ -432,10 +433,11 @@ impl DisputeResolution {
             DisputeOutcome::BuyerFavor => dispute.filed_by.clone(),
             DisputeOutcome::SellerFavor => dispute.respondent.clone(),
             DisputeOutcome::Split => dispute.filed_by.clone(),
+            DisputeOutcome::None => panic!("resolution must be specified"),
         };
 
         dispute.status = DisputeStatus::Resolved;
-        dispute.resolution = Some(outcome);
+        dispute.resolution = outcome;
         dispute.escrow_released = true;
         dispute.resolved_at = now;
 

--- a/contracts/src/governance.rs
+++ b/contracts/src/governance.rs
@@ -44,6 +44,65 @@ pub enum GovDataKey {
     SnapshotExpiry(u64),
     /// Next snapshot id counter
     NextSnapshotId,
+    /// Current registered version for a given proposal template (Issue #211)
+    TemplateVersion(ProposalTemplate),
+    /// Template metadata attached to a proposal id (Issue #211)
+    TemplateMeta(u64),
+}
+
+// ---------------------------------------------------------------------------
+// Governance Proposal Templates (Issue #211)
+// ---------------------------------------------------------------------------
+
+/// Pre-defined templates for common governance actions. Each template encodes
+/// the *shape* of a proposal so the front-end and validators can reason about
+/// the parameters without parsing free-form descriptions.
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[contracttype]
+pub enum ProposalTemplate {
+    /// Change a protocol fee (param_u64 = new fee in bps).
+    FeeChange,
+    /// Update a generic numeric protocol parameter (param_i128 = new value).
+    ParameterUpdate,
+    /// Upgrade a contract to new code (target = contract address).
+    ContractUpgrade,
+    /// Spend from the treasury (param_i128 = amount, target = recipient).
+    TreasurySpend,
+    /// Change the governance quorum threshold (param_i128 = new quorum).
+    QuorumChange,
+    /// List / approve an asset for trading (param_u64 = asset id).
+    AddAsset,
+    /// Delist / remove an asset (param_u64 = asset id).
+    RemoveAsset,
+    /// Toggle an emergency pause (param_u64 = scope id, param_i128 = 1 on / 0 off).
+    PauseToggle,
+    /// Change the per-delegatee delegation limit (param_u64 = new limit).
+    DelegationLimitChange,
+    /// Signaling-only text proposal (no executable parameters).
+    TextProposal,
+}
+
+/// Bounds applied to a template's parameters during validation.
+struct TemplateBounds {
+    /// Inclusive min / max for `param_u64` (when used).
+    u64_min: u64,
+    u64_max: u64,
+    /// Inclusive min / max for `param_i128` (when used).
+    i128_min: i128,
+    i128_max: i128,
+    /// Whether a non-`None` `target` address is required.
+    requires_target: bool,
+}
+
+/// Metadata recorded for a proposal created from a template.
+#[derive(Clone)]
+#[contracttype]
+pub struct TemplateProposal {
+    pub template: ProposalTemplate,
+    pub version: u32,
+    pub param_u64: u64,
+    pub param_i128: i128,
+    pub target: Option<Address>,
 }
 
 // ---------------------------------------------------------------------------
@@ -714,8 +773,233 @@ impl Governance {
     }
 
     // -----------------------------------------------------------------------
+    // Proposal Templates – Issue #211
+    // -----------------------------------------------------------------------
+
+    /// Register (or bump) the active version of a proposal template. Admin only.
+    /// Template versioning lets the protocol evolve a template's accepted
+    /// parameters while rejecting proposals built against a stale schema.
+    pub fn register_template_version(
+        env: Env,
+        admin: Address,
+        template: ProposalTemplate,
+        version: u32,
+    ) {
+        Self::require_admin(&env, &admin);
+        if version == 0 {
+            panic!("template version must be >= 1");
+        }
+        env.storage()
+            .instance()
+            .set(&GovDataKey::TemplateVersion(template), &version);
+        env.events().publish(
+            (Symbol::new(&env, "template_version_set"),),
+            (template, version),
+        );
+    }
+
+    /// Return the currently registered version for a template (defaults to 1).
+    pub fn get_template_version(env: Env, template: ProposalTemplate) -> u32 {
+        env.storage()
+            .instance()
+            .get(&GovDataKey::TemplateVersion(template))
+            .unwrap_or(1)
+    }
+
+    /// Read-only validation of a set of template parameters. Returns `true` if
+    /// the version is current and every parameter is within bounds. Intended for
+    /// off-chain pre-flight checks before submitting a proposal.
+    pub fn validate_template_params(
+        env: Env,
+        template: ProposalTemplate,
+        version: u32,
+        param_u64: u64,
+        param_i128: i128,
+        target: Option<Address>,
+    ) -> bool {
+        if version != Self::get_template_version(env, template) {
+            return false;
+        }
+        let bounds = Self::template_bounds(&template);
+        Self::params_within_bounds(&bounds, param_u64, param_i128, &target)
+    }
+
+    /// Create a governance proposal from a pre-defined template (Issue #211).
+    ///
+    /// Validates the template version and enforces per-template parameter bounds
+    /// before delegating to [`Governance::create_proposal`] for the usual
+    /// deposit / snapshot / auth handling. The structured parameters are stored
+    /// alongside the proposal for later execution and indexing.
+    pub fn create_proposal_from_template(
+        env: Env,
+        proposer: Address,
+        template: ProposalTemplate,
+        version: u32,
+        param_u64: u64,
+        param_i128: i128,
+        target: Option<Address>,
+        description: String,
+        duration: u64,
+    ) -> u64 {
+        // Reject proposals built against an unsupported template schema.
+        if version != Self::get_template_version(env.clone(), template) {
+            panic!("unsupported template version");
+        }
+
+        let bounds = Self::template_bounds(&template);
+        if bounds.requires_target && target.is_none() {
+            panic!("template requires a target address");
+        }
+        if !Self::params_within_bounds(&bounds, param_u64, param_i128, &target) {
+            panic!("template parameters out of bounds");
+        }
+
+        // Asset-oriented templates feed their asset id through to the base
+        // proposal so a passing vote approves the right asset; all other
+        // templates use the neutral sentinel `0`.
+        let asset_id = match template {
+            ProposalTemplate::AddAsset | ProposalTemplate::RemoveAsset => param_u64,
+            _ => 0,
+        };
+
+        let proposal_id =
+            Self::create_proposal(env.clone(), proposer.clone(), asset_id, description, duration);
+
+        let meta = TemplateProposal {
+            template,
+            version,
+            param_u64,
+            param_i128,
+            target,
+        };
+        env.storage()
+            .persistent()
+            .set(&GovDataKey::TemplateMeta(proposal_id), &meta);
+
+        env.events().publish(
+            (Symbol::new(&env, "template_proposal_created"), proposal_id),
+            (proposer, template, version),
+        );
+
+        proposal_id
+    }
+
+    /// Return the template metadata attached to a proposal, if any.
+    pub fn get_template_proposal(env: Env, proposal_id: u64) -> Option<TemplateProposal> {
+        env.storage()
+            .persistent()
+            .get(&GovDataKey::TemplateMeta(proposal_id))
+    }
+
+    /// List every supported proposal template.
+    pub fn list_templates(env: Env) -> Vec<ProposalTemplate> {
+        let mut v = Vec::new(&env);
+        v.push_back(ProposalTemplate::FeeChange);
+        v.push_back(ProposalTemplate::ParameterUpdate);
+        v.push_back(ProposalTemplate::ContractUpgrade);
+        v.push_back(ProposalTemplate::TreasurySpend);
+        v.push_back(ProposalTemplate::QuorumChange);
+        v.push_back(ProposalTemplate::AddAsset);
+        v.push_back(ProposalTemplate::RemoveAsset);
+        v.push_back(ProposalTemplate::PauseToggle);
+        v.push_back(ProposalTemplate::DelegationLimitChange);
+        v.push_back(ProposalTemplate::TextProposal);
+        v
+    }
+
+    // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
+
+    /// Per-template parameter bounds. Centralises the limits enforced for every
+    /// template so validation stays consistent across entry points.
+    fn template_bounds(template: &ProposalTemplate) -> TemplateBounds {
+        match template {
+            // Fee expressed in bps; capped at 10% to prevent confiscatory fees.
+            ProposalTemplate::FeeChange => TemplateBounds {
+                u64_min: 0,
+                u64_max: 1_000,
+                i128_min: 0,
+                i128_max: 0,
+                requires_target: false,
+            },
+            ProposalTemplate::ParameterUpdate => TemplateBounds {
+                u64_min: 0,
+                u64_max: u64::MAX,
+                i128_min: 0,
+                i128_max: i128::MAX,
+                requires_target: false,
+            },
+            ProposalTemplate::ContractUpgrade => TemplateBounds {
+                u64_min: 0,
+                u64_max: u64::MAX,
+                i128_min: 0,
+                i128_max: 0,
+                requires_target: true,
+            },
+            ProposalTemplate::TreasurySpend => TemplateBounds {
+                u64_min: 0,
+                u64_max: u64::MAX,
+                i128_min: 1,
+                i128_max: i128::MAX,
+                requires_target: true,
+            },
+            ProposalTemplate::QuorumChange => TemplateBounds {
+                u64_min: 0,
+                u64_max: u64::MAX,
+                i128_min: 1,
+                i128_max: i128::MAX,
+                requires_target: false,
+            },
+            ProposalTemplate::AddAsset | ProposalTemplate::RemoveAsset => TemplateBounds {
+                u64_min: 1,
+                u64_max: u64::MAX,
+                i128_min: 0,
+                i128_max: 0,
+                requires_target: false,
+            },
+            // param_i128 acts as a boolean flag (0 = off, 1 = on).
+            ProposalTemplate::PauseToggle => TemplateBounds {
+                u64_min: 0,
+                u64_max: u64::MAX,
+                i128_min: 0,
+                i128_max: 1,
+                requires_target: false,
+            },
+            ProposalTemplate::DelegationLimitChange => TemplateBounds {
+                u64_min: 1,
+                u64_max: 10_000,
+                i128_min: 0,
+                i128_max: 0,
+                requires_target: false,
+            },
+            ProposalTemplate::TextProposal => TemplateBounds {
+                u64_min: 0,
+                u64_max: 0,
+                i128_min: 0,
+                i128_max: 0,
+                requires_target: false,
+            },
+        }
+    }
+
+    fn params_within_bounds(
+        bounds: &TemplateBounds,
+        param_u64: u64,
+        param_i128: i128,
+        target: &Option<Address>,
+    ) -> bool {
+        if param_u64 < bounds.u64_min || param_u64 > bounds.u64_max {
+            return false;
+        }
+        if param_i128 < bounds.i128_min || param_i128 > bounds.i128_max {
+            return false;
+        }
+        if bounds.requires_target && target.is_none() {
+            return false;
+        }
+        true
+    }
 
     fn require_admin(env: &Env, caller: &Address) {
         let admin: Address = env

--- a/contracts/src/liquidity_pool.rs
+++ b/contracts/src/liquidity_pool.rs
@@ -1,6 +1,61 @@
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, Vec};
 
 // ============================================================================
+// Constants
+// ============================================================================
+
+/// Fixed-point precision used for the per-LP-token fee accumulators.
+/// Fees are scaled by this factor when accrued so that small per-token
+/// amounts are not lost to integer truncation.
+const FEE_PRECISION: i128 = 1_000_000_000_000; // 1e12
+
+/// Fixed-point scale used when recording spot prices for the TWAP oracle.
+const PRICE_SCALE: i128 = 10_000_000; // 1e7
+
+// ============================================================================
+// Fee Tiers (Issue #209)
+// ============================================================================
+
+/// Pre-defined fee tiers for liquidity pools.
+///
+/// Each tier targets a different class of asset pair:
+/// * `Low`    – 0.05% (5 bps)   – stable / correlated pairs.
+/// * `Medium` – 0.30% (30 bps)  – standard pairs (default).
+/// * `High`   – 1.00% (100 bps) – volatile / exotic pairs.
+#[derive(Clone, Copy, PartialEq, Debug)]
+#[contracttype]
+pub enum FeeTier {
+    Low,
+    Medium,
+    High,
+}
+
+impl FeeTier {
+    /// Fee charged by this tier in basis points.
+    pub fn to_bps(&self) -> u32 {
+        match self {
+            FeeTier::Low => 5,
+            FeeTier::Medium => 30,
+            FeeTier::High => 100,
+        }
+    }
+
+    /// Classify an arbitrary basis-point value into the nearest tier.
+    /// Used to keep backward compatibility with `create_pool`, which accepts
+    /// a raw `fee_bps` value.
+    fn classify(fee_bps: u32) -> FeeTier {
+        // Midpoints: (5,30) -> 17, (30,100) -> 65
+        if fee_bps <= 17 {
+            FeeTier::Low
+        } else if fee_bps <= 65 {
+            FeeTier::Medium
+        } else {
+            FeeTier::High
+        }
+    }
+}
+
+// ============================================================================
 // Data Types
 // ============================================================================
 
@@ -14,6 +69,16 @@ pub struct Pool {
     pub reserve_b: i128,
     pub total_lp: i128,
     pub fee_bps: u32,
+    pub fee_tier: FeeTier,
+    /// Cumulative fees (asset_a) accrued per LP token, scaled by `FEE_PRECISION`.
+    pub acc_fee_per_share_a: i128,
+    /// Cumulative fees (asset_b) accrued per LP token, scaled by `FEE_PRECISION`.
+    pub acc_fee_per_share_b: i128,
+    /// Time-weighted cumulative price of asset_a denominated in asset_b
+    /// (scaled by `PRICE_SCALE`). Powers the TWAP oracle.
+    pub price_cumulative: i128,
+    /// Ledger timestamp at which `price_cumulative` was last updated.
+    pub last_twap_ts: u64,
     pub creator: Address,
     pub active: bool,
 }
@@ -24,7 +89,13 @@ pub struct LPPosition {
     pub pool_id: u64,
     pub provider: Address,
     pub lp_tokens: i128,
-    pub fees_earned: i128,
+    /// Settled, claimable fees accrued in asset_a.
+    pub fees_earned_a: i128,
+    /// Settled, claimable fees accrued in asset_b.
+    pub fees_earned_b: i128,
+    /// Fee accounting checkpoints (reward-debt pattern).
+    pub fee_debt_a: i128,
+    pub fee_debt_b: i128,
 }
 
 #[derive(Clone)]
@@ -35,14 +106,44 @@ pub struct SwapResult {
     pub price_impact_bps: u32,
 }
 
+/// Flash-loan protection parameters (Issue #210). All limits default to the
+/// permissive value (0 / unlimited) so that existing behaviour is preserved
+/// until an admin explicitly tightens them.
+#[derive(Clone)]
+#[contracttype]
+pub struct TradeGuardConfig {
+    /// Maximum number of swaps allowed against a single pool within one ledger
+    /// (block). `0` disables the limit.
+    pub max_trades_per_block: u32,
+    /// Minimum number of seconds that must elapse between adding liquidity and
+    /// withdrawing it. `0` disables the cooldown.
+    pub deposit_withdraw_cooldown: u64,
+    /// Spot-vs-TWAP deviation (in bps) above which a `price_deviation_alert`
+    /// event is emitted. `0` disables deviation alerts.
+    pub max_price_deviation_bps: u32,
+}
+
+/// A stored TWAP anchor used to compute the average price over a window.
+#[derive(Clone)]
+#[contracttype]
+pub struct TwapObservation {
+    pub timestamp: u64,
+    pub price_cumulative: i128,
+}
+
 #[derive(Clone)]
 #[contracttype]
 pub enum LPDataKey {
     Admin,
     PoolNonce,
     Pool(u64),
-    Position(u64, Address),  // (pool_id, provider)
-    PoolIndex,               // Vec<u64> of all pool IDs
+    Position(u64, Address), // (pool_id, provider)
+    PoolIndex,              // Vec<u64> of all pool IDs
+    // --- Flash-loan protection (Issue #210) ---
+    GuardConfig,                  // TradeGuardConfig (instance)
+    BlockTrades(u64, u32),        // (pool_id, ledger_seq) -> u32 swap count
+    LastDeposit(u64, Address),    // (pool_id, provider) -> timestamp
+    Twap(u64),                    // pool_id -> TwapObservation anchor
 }
 
 // ============================================================================
@@ -62,7 +163,10 @@ impl LiquidityPool {
         env.storage().instance().set(&LPDataKey::Admin, &admin);
     }
 
-    /// Create a new AMM pool for two assets.
+    /// Create a new AMM pool for two assets using a raw fee (basis points).
+    ///
+    /// Retained for backward compatibility. The supplied `fee_bps` is mapped to
+    /// the nearest pre-defined [`FeeTier`] for reporting purposes.
     pub fn create_pool(
         env: Env,
         creator: Address,
@@ -70,13 +174,38 @@ impl LiquidityPool {
         asset_b: u64,
         fee_bps: u32,
     ) -> u64 {
+        if fee_bps > 10_000 {
+            panic!("fee_bps must not exceed 10000");
+        }
+        let tier = FeeTier::classify(fee_bps);
+        Self::create_pool_internal(env, creator, asset_a, asset_b, fee_bps, tier)
+    }
+
+    /// Create a new AMM pool choosing one of the pre-defined fee tiers
+    /// (Issue #209). The pool's `fee_bps` is derived from the tier.
+    pub fn create_pool_with_tier(
+        env: Env,
+        creator: Address,
+        asset_a: u64,
+        asset_b: u64,
+        tier: FeeTier,
+    ) -> u64 {
+        let fee_bps = tier.to_bps();
+        Self::create_pool_internal(env, creator, asset_a, asset_b, fee_bps, tier)
+    }
+
+    fn create_pool_internal(
+        env: Env,
+        creator: Address,
+        asset_a: u64,
+        asset_b: u64,
+        fee_bps: u32,
+        tier: FeeTier,
+    ) -> u64 {
         creator.require_auth();
 
         if asset_a == asset_b {
             panic!("pool assets must be different");
-        }
-        if fee_bps > 10_000 {
-            panic!("fee_bps must not exceed 10000");
         }
 
         // Canonical asset ordering to prevent duplicate pools
@@ -106,9 +235,7 @@ impl LiquidityPool {
             .get(&LPDataKey::PoolNonce)
             .unwrap_or(0)
             + 1;
-        env.storage()
-            .instance()
-            .set(&LPDataKey::PoolNonce, &pool_id);
+        env.storage().instance().set(&LPDataKey::PoolNonce, &pool_id);
 
         let pool = Pool {
             id: pool_id,
@@ -118,13 +245,16 @@ impl LiquidityPool {
             reserve_b: 0,
             total_lp: 0,
             fee_bps,
+            fee_tier: tier,
+            acc_fee_per_share_a: 0,
+            acc_fee_per_share_b: 0,
+            price_cumulative: 0,
+            last_twap_ts: env.ledger().timestamp(),
             creator: creator.clone(),
             active: true,
         };
 
-        env.storage()
-            .persistent()
-            .set(&LPDataKey::Pool(pool_id), &pool);
+        env.storage().persistent().set(&LPDataKey::Pool(pool_id), &pool);
 
         let mut index: Vec<u64> = pool_ids;
         index.push_back(pool_id);
@@ -132,7 +262,7 @@ impl LiquidityPool {
 
         env.events().publish(
             (Symbol::new(&env, "pool_created"), pool_id),
-            (creator, a, b, fee_bps),
+            (creator, a, b, fee_bps, tier),
         );
 
         pool_id
@@ -162,16 +292,15 @@ impl LiquidityPool {
             panic!("pool is inactive");
         }
 
+        // Update the TWAP accumulator using the reserves in effect so far.
+        Self::accumulate_price(&env, &mut pool);
+
         let lp_tokens = if pool.total_lp == 0 {
             // Initial liquidity — integer approximation of sqrt(a*b)
             Self::isqrt(amount_a.saturating_mul(amount_b))
         } else {
-            let lp_a = amount_a
-                .saturating_mul(pool.total_lp)
-                / pool.reserve_a;
-            let lp_b = amount_b
-                .saturating_mul(pool.total_lp)
-                / pool.reserve_b;
+            let lp_a = amount_a.saturating_mul(pool.total_lp) / pool.reserve_a;
+            let lp_b = amount_b.saturating_mul(pool.total_lp) / pool.reserve_b;
             lp_a.min(lp_b)
         };
 
@@ -183,10 +312,6 @@ impl LiquidityPool {
         pool.reserve_b = pool.reserve_b.saturating_add(amount_b);
         pool.total_lp = pool.total_lp.saturating_add(lp_tokens);
 
-        env.storage()
-            .persistent()
-            .set(&LPDataKey::Pool(pool_id), &pool);
-
         let mut position: LPPosition = env
             .storage()
             .persistent()
@@ -195,13 +320,27 @@ impl LiquidityPool {
                 pool_id,
                 provider: provider.clone(),
                 lp_tokens: 0,
-                fees_earned: 0,
+                fees_earned_a: 0,
+                fees_earned_b: 0,
+                fee_debt_a: 0,
+                fee_debt_b: 0,
             });
 
+        // Settle any fees accrued on the existing balance before changing it.
+        Self::settle_position(&pool, &mut position);
         position.lp_tokens = position.lp_tokens.saturating_add(lp_tokens);
+        Self::reset_fee_debt(&pool, &mut position);
+
+        env.storage().persistent().set(&LPDataKey::Pool(pool_id), &pool);
         env.storage()
             .persistent()
             .set(&LPDataKey::Position(pool_id, provider.clone()), &position);
+
+        // Record the deposit time to enforce withdrawal cooldowns (Issue #210).
+        env.storage().persistent().set(
+            &LPDataKey::LastDeposit(pool_id, provider.clone()),
+            &env.ledger().timestamp(),
+        );
 
         env.events().publish(
             (Symbol::new(&env, "liquidity_added"), pool_id),
@@ -234,6 +373,11 @@ impl LiquidityPool {
             panic!("pool has no liquidity");
         }
 
+        // Enforce the deposit/withdraw cooldown (Issue #210).
+        Self::enforce_withdraw_cooldown(&env, pool_id, &provider);
+
+        Self::accumulate_price(&env, &mut pool);
+
         let mut position: LPPosition = env
             .storage()
             .persistent()
@@ -257,11 +401,12 @@ impl LiquidityPool {
             pool.reserve_b = 0;
         }
 
-        env.storage()
-            .persistent()
-            .set(&LPDataKey::Pool(pool_id), &pool);
-
+        // Settle fees on the current balance, then shrink the position.
+        Self::settle_position(&pool, &mut position);
         position.lp_tokens -= lp_tokens;
+        Self::reset_fee_debt(&pool, &mut position);
+
+        env.storage().persistent().set(&LPDataKey::Pool(pool_id), &pool);
         env.storage()
             .persistent()
             .set(&LPDataKey::Position(pool_id, provider.clone()), &position);
@@ -275,6 +420,10 @@ impl LiquidityPool {
     }
 
     /// Execute a swap using the constant-product AMM formula.
+    ///
+    /// The fee is diverted to the per-LP fee accumulators (Issue #209) rather
+    /// than compounding into the reserves, so liquidity providers can claim
+    /// their proportional share via [`LiquidityPool::claim_fees`].
     pub fn swap(
         env: Env,
         trader: Address,
@@ -299,6 +448,12 @@ impl LiquidityPool {
             panic!("pool is inactive");
         }
 
+        // Flash-loan guard: cap the number of swaps per pool per ledger.
+        Self::enforce_block_trade_limit(&env, pool_id);
+
+        // Update the TWAP accumulator with the pre-swap reserves.
+        Self::accumulate_price(&env, &mut pool);
+
         let (reserve_in, reserve_out, is_a_to_b) = if input_asset == pool.asset_a {
             (pool.reserve_a, pool.reserve_b, true)
         } else if input_asset == pool.asset_b {
@@ -312,14 +467,11 @@ impl LiquidityPool {
         }
 
         let fee_bps = pool.fee_bps as i128;
-        let amount_in_after_fee = input_amount
-            .saturating_mul(10_000 - fee_bps)
-            / 10_000;
+        let amount_in_after_fee = input_amount.saturating_mul(10_000 - fee_bps) / 10_000;
         let fee_amount = input_amount - amount_in_after_fee;
 
         // x * y = k → output = dy = y * dx' / (x + dx')
-        let output_amount = amount_in_after_fee
-            .saturating_mul(reserve_out)
+        let output_amount = amount_in_after_fee.saturating_mul(reserve_out)
             / reserve_in.saturating_add(amount_in_after_fee);
 
         if output_amount <= 0 {
@@ -332,23 +484,37 @@ impl LiquidityPool {
 
         let price_impact_bps = (output_amount.saturating_mul(10_000) / reserve_out) as u32;
 
+        // Accrue the fee proportionally to all LPs via the per-share accumulator.
+        if pool.total_lp > 0 && fee_amount > 0 {
+            let per_share = fee_amount.saturating_mul(FEE_PRECISION) / pool.total_lp;
+            if is_a_to_b {
+                pool.acc_fee_per_share_a = pool.acc_fee_per_share_a.saturating_add(per_share);
+            } else {
+                pool.acc_fee_per_share_b = pool.acc_fee_per_share_b.saturating_add(per_share);
+            }
+        }
+
+        // Only the post-fee amount enters the reserves; the fee sits in the
+        // accumulator awaiting LP claims.
         if is_a_to_b {
-            pool.reserve_a = pool.reserve_a.saturating_add(input_amount);
+            pool.reserve_a = pool.reserve_a.saturating_add(amount_in_after_fee);
             pool.reserve_b -= output_amount;
             if pool.reserve_b < 0 {
                 pool.reserve_b = 0;
             }
         } else {
-            pool.reserve_b = pool.reserve_b.saturating_add(input_amount);
+            pool.reserve_b = pool.reserve_b.saturating_add(amount_in_after_fee);
             pool.reserve_a -= output_amount;
             if pool.reserve_a < 0 {
                 pool.reserve_a = 0;
             }
         }
 
-        env.storage()
-            .persistent()
-            .set(&LPDataKey::Pool(pool_id), &pool);
+        env.storage().persistent().set(&LPDataKey::Pool(pool_id), &pool);
+
+        // Emit a price-deviation alert if the post-swap spot price strays too
+        // far from the TWAP (Issue #210).
+        Self::maybe_emit_deviation_alert(&env, &pool);
 
         env.events().publish(
             (Symbol::new(&env, "swap_executed"), pool_id),
@@ -362,11 +528,233 @@ impl LiquidityPool {
         }
     }
 
-    /// Get pool details.
-    pub fn get_pool(env: Env, pool_id: u64) -> Option<Pool> {
-        env.storage()
+    /// Claim the caller's accrued share of pool fees (Issue #209).
+    /// Returns the claimed (asset_a, asset_b) fee amounts.
+    pub fn claim_fees(env: Env, provider: Address, pool_id: u64) -> (i128, i128) {
+        provider.require_auth();
+
+        let pool: Pool = env
+            .storage()
             .persistent()
             .get(&LPDataKey::Pool(pool_id))
+            .expect("pool not found");
+
+        let mut position: LPPosition = env
+            .storage()
+            .persistent()
+            .get(&LPDataKey::Position(pool_id, provider.clone()))
+            .expect("no LP position found");
+
+        Self::settle_position(&pool, &mut position);
+
+        let claimed_a = position.fees_earned_a;
+        let claimed_b = position.fees_earned_b;
+        position.fees_earned_a = 0;
+        position.fees_earned_b = 0;
+
+        env.storage()
+            .persistent()
+            .set(&LPDataKey::Position(pool_id, provider.clone()), &position);
+
+        env.events().publish(
+            (Symbol::new(&env, "fees_claimed"), pool_id),
+            (provider, claimed_a, claimed_b),
+        );
+
+        (claimed_a, claimed_b)
+    }
+
+    /// Return the currently claimable (unsettled + settled) fees for a provider.
+    pub fn pending_fees(env: Env, pool_id: u64, provider: Address) -> (i128, i128) {
+        let pool: Pool = match env.storage().persistent().get(&LPDataKey::Pool(pool_id)) {
+            Some(p) => p,
+            None => return (0, 0),
+        };
+        let position: LPPosition = match env
+            .storage()
+            .persistent()
+            .get(&LPDataKey::Position(pool_id, provider))
+        {
+            Some(p) => p,
+            None => return (0, 0),
+        };
+        let (pending_a, pending_b) = Self::pending(&pool, &position);
+        (
+            position.fees_earned_a.saturating_add(pending_a),
+            position.fees_earned_b.saturating_add(pending_b),
+        )
+    }
+
+    /// Migrate a pool to a new fee tier (Issue #209).
+    ///
+    /// Outstanding fees are settled into the accumulator before the change so
+    /// that no LP is over- or under-credited across the migration boundary.
+    /// Callable by the pool creator or the contract admin.
+    pub fn migrate_fee_tier(env: Env, caller: Address, pool_id: u64, new_tier: FeeTier) {
+        caller.require_auth();
+
+        let mut pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&LPDataKey::Pool(pool_id))
+            .expect("pool not found");
+
+        let is_creator = caller == pool.creator;
+        let is_admin = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&LPDataKey::Admin)
+            .map(|a| a == caller)
+            .unwrap_or(false);
+        if !is_creator && !is_admin {
+            panic!("only pool creator or admin can migrate fee tier");
+        }
+
+        let old_tier = pool.fee_tier;
+        pool.fee_tier = new_tier;
+        pool.fee_bps = new_tier.to_bps();
+
+        env.storage().persistent().set(&LPDataKey::Pool(pool_id), &pool);
+
+        env.events().publish(
+            (Symbol::new(&env, "fee_tier_migrated"), pool_id),
+            (caller, old_tier, new_tier, pool.fee_bps),
+        );
+    }
+
+    /// Recommend a fee tier for a pair based on its observed volatility and
+    /// liquidity depth (Issue #209). Pure helper — does not touch storage.
+    ///
+    /// * `volatility_bps` – recent price volatility expressed in basis points.
+    /// * `liquidity_depth` – total value locked (in asset_b units) available.
+    pub fn recommend_tier(_env: Env, volatility_bps: u32, liquidity_depth: i128) -> FeeTier {
+        // Highly volatile pairs warrant the highest fee to compensate LPs for
+        // impermanent loss risk.
+        if volatility_bps >= 500 {
+            return FeeTier::High;
+        }
+        // Low-volatility, deeply-liquid pairs (e.g. stable pairs) can sustain
+        // the cheapest tier and still reward LPs on volume.
+        if volatility_bps <= 50 && liquidity_depth >= 1_000_000 {
+            return FeeTier::Low;
+        }
+        FeeTier::Medium
+    }
+
+    // -----------------------------------------------------------------------
+    // TWAP oracle (Issue #210)
+    // -----------------------------------------------------------------------
+
+    /// Store the current cumulative price as the new TWAP anchor. Permissionless;
+    /// anyone may refresh the window the average is measured over.
+    pub fn snapshot_twap(env: Env, pool_id: u64) {
+        let mut pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&LPDataKey::Pool(pool_id))
+            .expect("pool not found");
+        Self::accumulate_price(&env, &mut pool);
+        env.storage().persistent().set(&LPDataKey::Pool(pool_id), &pool);
+
+        let obs = TwapObservation {
+            timestamp: env.ledger().timestamp(),
+            price_cumulative: pool.price_cumulative,
+        };
+        env.storage().persistent().set(&LPDataKey::Twap(pool_id), &obs);
+
+        env.events().publish(
+            (Symbol::new(&env, "twap_snapshot"), pool_id),
+            (obs.timestamp, obs.price_cumulative),
+        );
+    }
+
+    /// Return the time-weighted average price of asset_a (denominated in
+    /// asset_b, scaled by `PRICE_SCALE`) since the last stored anchor.
+    ///
+    /// Falls back to the current spot price when no anchor exists or no time
+    /// has elapsed since the anchor was taken.
+    pub fn get_twap(env: Env, pool_id: u64) -> i128 {
+        let pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&LPDataKey::Pool(pool_id))
+            .expect("pool not found");
+
+        let now = env.ledger().timestamp();
+        let cum_now = Self::current_cumulative(&pool, now);
+
+        if let Some(anchor) = env
+            .storage()
+            .persistent()
+            .get::<_, TwapObservation>(&LPDataKey::Twap(pool_id))
+        {
+            let dt = now.saturating_sub(anchor.timestamp);
+            if dt > 0 {
+                return (cum_now - anchor.price_cumulative) / dt as i128;
+            }
+        }
+        Self::spot_price(&pool)
+    }
+
+    /// Current spot price of asset_a in asset_b, scaled by `PRICE_SCALE`.
+    pub fn get_spot_price(env: Env, pool_id: u64) -> i128 {
+        let pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&LPDataKey::Pool(pool_id))
+            .expect("pool not found");
+        Self::spot_price(&pool)
+    }
+
+    /// Current deviation (in bps) of the spot price from the TWAP.
+    pub fn price_deviation_bps(env: Env, pool_id: u64) -> u32 {
+        let pool: Pool = env
+            .storage()
+            .persistent()
+            .get(&LPDataKey::Pool(pool_id))
+            .expect("pool not found");
+        let spot = Self::spot_price(&pool);
+        let twap = Self::get_twap(env, pool_id);
+        Self::deviation_bps(spot, twap)
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin: flash-loan guard configuration (Issue #210)
+    // -----------------------------------------------------------------------
+
+    /// Configure the flash-loan protection parameters. Admin only.
+    pub fn set_guard_config(
+        env: Env,
+        admin: Address,
+        max_trades_per_block: u32,
+        deposit_withdraw_cooldown: u64,
+        max_price_deviation_bps: u32,
+    ) {
+        Self::require_admin(&env, &admin);
+        let cfg = TradeGuardConfig {
+            max_trades_per_block,
+            deposit_withdraw_cooldown,
+            max_price_deviation_bps,
+        };
+        env.storage().instance().set(&LPDataKey::GuardConfig, &cfg);
+        env.events().publish(
+            (Symbol::new(&env, "guard_config_set"),),
+            (max_trades_per_block, deposit_withdraw_cooldown, max_price_deviation_bps),
+        );
+    }
+
+    /// Return the active flash-loan guard configuration (defaults to permissive).
+    pub fn get_guard_config(env: Env) -> TradeGuardConfig {
+        Self::guard_config(&env)
+    }
+
+    // -----------------------------------------------------------------------
+    // Query helpers
+    // -----------------------------------------------------------------------
+
+    /// Get pool details.
+    pub fn get_pool(env: Env, pool_id: u64) -> Option<Pool> {
+        env.storage().persistent().get(&LPDataKey::Pool(pool_id))
     }
 
     /// Get LP position for a provider.
@@ -393,9 +781,7 @@ impl LiquidityPool {
             .get(&LPDataKey::Pool(pool_id))
             .expect("pool not found");
         pool.active = false;
-        env.storage()
-            .persistent()
-            .set(&LPDataKey::Pool(pool_id), &pool);
+        env.storage().persistent().set(&LPDataKey::Pool(pool_id), &pool);
         env.events()
             .publish((Symbol::new(&env, "pool_deactivated"), pool_id), admin);
     }
@@ -404,11 +790,127 @@ impl LiquidityPool {
     // Internal helpers
     // -----------------------------------------------------------------------
 
-    fn isqrt(n: i128) -> i128 {
-        if n < 0 {
+    /// Spot price of asset_a in asset_b, scaled by `PRICE_SCALE`.
+    fn spot_price(pool: &Pool) -> i128 {
+        if pool.reserve_a <= 0 {
             return 0;
         }
-        if n == 0 {
+        pool.reserve_b.saturating_mul(PRICE_SCALE) / pool.reserve_a
+    }
+
+    /// Compute the cumulative price as of `now`, without persisting it.
+    fn current_cumulative(pool: &Pool, now: u64) -> i128 {
+        let elapsed = now.saturating_sub(pool.last_twap_ts);
+        if elapsed == 0 || pool.reserve_a <= 0 {
+            return pool.price_cumulative;
+        }
+        let spot = Self::spot_price(pool);
+        pool.price_cumulative
+            .saturating_add(spot.saturating_mul(elapsed as i128))
+    }
+
+    /// Advance the pool's stored cumulative price up to the current timestamp.
+    fn accumulate_price(env: &Env, pool: &mut Pool) {
+        let now = env.ledger().timestamp();
+        pool.price_cumulative = Self::current_cumulative(pool, now);
+        pool.last_twap_ts = now;
+    }
+
+    /// Absolute deviation between two prices, in basis points.
+    fn deviation_bps(spot: i128, reference: i128) -> u32 {
+        if reference <= 0 {
+            return 0;
+        }
+        let diff = (spot - reference).abs();
+        (diff.saturating_mul(10_000) / reference) as u32
+    }
+
+    fn maybe_emit_deviation_alert(env: &Env, pool: &Pool) {
+        let cfg = Self::guard_config(env);
+        if cfg.max_price_deviation_bps == 0 {
+            return;
+        }
+        let spot = Self::spot_price(pool);
+        let twap = Self::get_twap(env.clone(), pool.id);
+        let dev = Self::deviation_bps(spot, twap);
+        if dev > cfg.max_price_deviation_bps {
+            env.events().publish(
+                (Symbol::new(env, "price_deviation_alert"), pool.id),
+                (spot, twap, dev),
+            );
+        }
+    }
+
+    fn guard_config(env: &Env) -> TradeGuardConfig {
+        env.storage()
+            .instance()
+            .get(&LPDataKey::GuardConfig)
+            .unwrap_or(TradeGuardConfig {
+                max_trades_per_block: 0,
+                deposit_withdraw_cooldown: 0,
+                max_price_deviation_bps: 0,
+            })
+    }
+
+    fn enforce_block_trade_limit(env: &Env, pool_id: u64) {
+        let cfg = Self::guard_config(env);
+        if cfg.max_trades_per_block == 0 {
+            return;
+        }
+        let seq = env.ledger().sequence();
+        let key = LPDataKey::BlockTrades(pool_id, seq);
+        let count: u32 = env.storage().persistent().get(&key).unwrap_or(0);
+        if count >= cfg.max_trades_per_block {
+            panic!("per-block trade limit exceeded");
+        }
+        env.storage().persistent().set(&key, &(count + 1));
+    }
+
+    fn enforce_withdraw_cooldown(env: &Env, pool_id: u64, provider: &Address) {
+        let cfg = Self::guard_config(env);
+        if cfg.deposit_withdraw_cooldown == 0 {
+            return;
+        }
+        if let Some(last) = env
+            .storage()
+            .persistent()
+            .get::<_, u64>(&LPDataKey::LastDeposit(pool_id, provider.clone()))
+        {
+            let unlock = last.saturating_add(cfg.deposit_withdraw_cooldown);
+            if env.ledger().timestamp() < unlock {
+                panic!("deposit/withdraw cooldown active");
+            }
+        }
+    }
+
+    /// Pending (unsettled) fees for a position, given the current accumulator.
+    fn pending(pool: &Pool, position: &LPPosition) -> (i128, i128) {
+        let acc_a = position.lp_tokens.saturating_mul(pool.acc_fee_per_share_a) / FEE_PRECISION;
+        let acc_b = position.lp_tokens.saturating_mul(pool.acc_fee_per_share_b) / FEE_PRECISION;
+        (
+            (acc_a - position.fee_debt_a).max(0),
+            (acc_b - position.fee_debt_b).max(0),
+        )
+    }
+
+    /// Move pending fees into the settled `fees_earned` buckets.
+    fn settle_position(pool: &Pool, position: &mut LPPosition) {
+        let (pending_a, pending_b) = Self::pending(pool, position);
+        position.fees_earned_a = position.fees_earned_a.saturating_add(pending_a);
+        position.fees_earned_b = position.fees_earned_b.saturating_add(pending_b);
+        Self::reset_fee_debt(pool, position);
+    }
+
+    /// Re-checkpoint the position's fee debt to the current accumulator value.
+    fn reset_fee_debt(pool: &Pool, position: &mut LPPosition) {
+        position.fee_debt_a =
+            position.lp_tokens.saturating_mul(pool.acc_fee_per_share_a) / FEE_PRECISION;
+        position.fee_debt_b =
+            position.lp_tokens.saturating_mul(pool.acc_fee_per_share_b) / FEE_PRECISION;
+    }
+
+    fn isqrt(n: i128) -> i128 {
+        if n <= 0 {
             return 0;
         }
         let mut x = n;
@@ -468,6 +970,7 @@ mod test {
         let pool = client.get_pool(&pool_id).unwrap();
         assert_eq!(pool.reserve_a, 1_000_000);
         assert_eq!(pool.reserve_b, 1_000_000);
+        assert_eq!(pool.fee_tier, FeeTier::Medium);
     }
 
     #[test]
@@ -514,5 +1017,19 @@ mod test {
 
         client.create_pool(&creator, &1, &2, &30);
         client.create_pool(&creator, &1, &2, &30); // should panic
+    }
+
+    #[test]
+    fn test_create_pool_with_tier_sets_fee() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _) = setup(&env);
+        let creator = Address::generate(&env);
+
+        let pool_id = client.create_pool_with_tier(&creator, &1, &2, &FeeTier::Low);
+        let pool = client.get_pool(&pool_id).unwrap();
+        assert_eq!(pool.fee_tier, FeeTier::Low);
+        assert_eq!(pool.fee_bps, 5);
     }
 }

--- a/contracts/src/marketplace.rs
+++ b/contracts/src/marketplace.rs
@@ -194,6 +194,11 @@ pub enum MarketplaceDataKey {
     Oracle,
     BundleListings,
     BundleListing(u64),
+    // --- Flash-loan protection (Issue #210) ---
+    /// Flash-loan guard configuration (instance-level).
+    FlashLoanGuard,
+    /// Per-buyer purchase counter for a given ledger (block): (buyer, ledger_seq) -> u32.
+    BlockTrades(Address, u32),
 }
 
 /// Storage keys for buy-back and burn system.
@@ -265,6 +270,22 @@ pub struct BuyBackRecord {
     pub executor: Address,
     /// Whether this was an auto-triggered buy-back
     pub auto_triggered: bool,
+}
+
+/// Flash-loan protection configuration for the marketplace (Issue #210).
+///
+/// Both limits default to the permissive value (`0`) so existing behaviour is
+/// unchanged until an admin opts in via `configure_flash_loan_guard`.
+#[derive(Clone)]
+#[contracttype]
+pub struct FlashLoanGuardConfig {
+    /// Maximum number of purchases a single buyer may perform within one ledger
+    /// (block). `0` disables the limit. Caps the atomic, same-block churn that
+    /// flash-loan style attacks rely on.
+    pub max_trades_per_block: u32,
+    /// Maximum allowed deviation (bps) between a listing price and the oracle
+    /// price on a guarded purchase. `0` disables the on-chain price check.
+    pub max_price_deviation_bps: u32,
 }
 
 // ============================================================================
@@ -380,6 +401,9 @@ impl Marketplace {
     ) -> bool {
         assert!(amount > 0, "amount must be positive");
         buyer.require_auth();
+
+        // Flash-loan guard: cap how many purchases a buyer can make per block.
+        Self::enforce_block_trade_limit(&env, &buyer);
 
         // Enforce pause check for trading operations
         let ec_client = EmergencyControlClient::new(&env, &emergency_control_id);
@@ -771,6 +795,91 @@ impl Marketplace {
                 panic!("user not whitelisted for private asset");
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Flash-loan protection (Issue #210)
+    // -----------------------------------------------------------------------
+
+    /// Configure the marketplace flash-loan guard. Admin only.
+    ///
+    /// * `max_trades_per_block` – per-buyer purchase cap per ledger (0 = off).
+    /// * `max_price_deviation_bps` – max listing-vs-oracle deviation enforced by
+    ///   [`Marketplace::purchase_guarded`] (0 = off).
+    pub fn configure_flash_loan_guard(
+        env: Env,
+        admin: Address,
+        max_trades_per_block: u32,
+        max_price_deviation_bps: u32,
+    ) {
+        Self::require_admin(&env, &admin);
+        let cfg = FlashLoanGuardConfig {
+            max_trades_per_block,
+            max_price_deviation_bps,
+        };
+        env.storage()
+            .instance()
+            .set(&MarketplaceDataKey::FlashLoanGuard, &cfg);
+        env.events().publish(
+            (Symbol::new(&env, "flash_loan_guard_configured"),),
+            (max_trades_per_block, max_price_deviation_bps),
+        );
+    }
+
+    /// Return the active flash-loan guard configuration (defaults to permissive).
+    pub fn get_flash_loan_guard(env: Env) -> FlashLoanGuardConfig {
+        Self::flash_loan_guard(&env)
+    }
+
+    /// Purchase with both the per-block trade limit and an oracle price-deviation
+    /// check applied (Issue #210). Reverts if the listing price strays beyond the
+    /// configured deviation from the oracle, blocking price-manipulation exits.
+    pub fn purchase_guarded(
+        env: Env,
+        buyer: Address,
+        listing_id: u64,
+        amount: i128,
+        asset_id: u64,
+        emergency_control_id: Address,
+    ) -> bool {
+        let cfg = Self::flash_loan_guard(&env);
+        if cfg.max_price_deviation_bps > 0 {
+            let listing = Self::get_listing(env.clone(), listing_id).expect("listing not found");
+            assert!(
+                Self::validate_listing_price(
+                    env.clone(),
+                    asset_id,
+                    listing.price,
+                    cfg.max_price_deviation_bps
+                ),
+                "price deviates too much from oracle"
+            );
+        }
+        Self::purchase(env, buyer, listing_id, amount, asset_id, emergency_control_id)
+    }
+
+    fn flash_loan_guard(env: &Env) -> FlashLoanGuardConfig {
+        env.storage()
+            .instance()
+            .get(&MarketplaceDataKey::FlashLoanGuard)
+            .unwrap_or(FlashLoanGuardConfig {
+                max_trades_per_block: 0,
+                max_price_deviation_bps: 0,
+            })
+    }
+
+    fn enforce_block_trade_limit(env: &Env, buyer: &Address) {
+        let cfg = Self::flash_loan_guard(env);
+        if cfg.max_trades_per_block == 0 {
+            return;
+        }
+        let seq = env.ledger().sequence();
+        let key = MarketplaceDataKey::BlockTrades(buyer.clone(), seq);
+        let count: u32 = env.storage().persistent().get(&key).unwrap_or(0);
+        if count >= cfg.max_trades_per_block {
+            panic!("per-block trade limit exceeded");
+        }
+        env.storage().persistent().set(&key, &(count + 1));
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/src/staking_rewards.rs
+++ b/contracts/src/staking_rewards.rs
@@ -89,6 +89,7 @@ pub enum StakingDataKey {
     Distribution(u64),
     TotalStaked(u64),
     StrategyPerf(u64, StrategyType), // (asset_id, strategy)
+    PoolCapacity(u64),               // (asset_id) -> PoolCapacity
 }
 
 // ============================================================================

--- a/contracts/tests/governance_test.rs
+++ b/contracts/tests/governance_test.rs
@@ -1,0 +1,255 @@
+// Integration tests for governance proposal templates (Issue #211).
+//
+// Covers template listing, versioning, parameter-bounds validation, and
+// end-to-end proposal creation from a template.
+
+#![cfg(test)]
+
+extern crate kor_assetforge_contracts;
+
+use kor_assetforge_contracts::asset_token::{AssetToken, AssetTokenClient};
+use kor_assetforge_contracts::emergency_control::EmergencyControl;
+use kor_assetforge_contracts::governance::{
+    Governance, GovernanceClient, ProposalStatus, ProposalTemplate,
+};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env, String};
+
+fn setup() -> (Env, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ec_id = env.register_contract(None, EmergencyControl);
+    let ec_client =
+        kor_assetforge_contracts::emergency_control::EmergencyControlClient::new(&env, &ec_id);
+    let admin = Address::generate(&env);
+    ec_client.initialize(&admin);
+
+    let at_id = env.register_contract(None, AssetToken);
+    let at_client = AssetTokenClient::new(&env, &at_id);
+    at_client.initialize(
+        &admin,
+        &String::from_str(&env, "GovToken"),
+        &String::from_str(&env, "GOV"),
+        &7,
+        &0,
+    );
+
+    let gov_id = env.register_contract(None, Governance);
+    let gov_client = GovernanceClient::new(&env, &gov_id);
+    gov_client.initialize(&admin, &at_id, &100, &50);
+
+    (env, gov_id, at_id, ec_id, admin)
+}
+
+fn mint(env: &Env, at_id: &Address, ec_id: &Address, to: &Address, amount: i128) {
+    let at_client = AssetTokenClient::new(env, at_id);
+    at_client.mint(to, &amount, &1, ec_id);
+}
+
+// ---------------------------------------------------------------------------
+// Listing & versioning
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_list_templates_returns_full_catalogue() {
+    let (env, gov_id, _at, _ec, _admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+    assert_eq!(client.list_templates().len(), 10);
+}
+
+#[test]
+fn test_template_version_defaults_to_one() {
+    let (env, gov_id, _at, _ec, _admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+    assert_eq!(client.get_template_version(&ProposalTemplate::FeeChange), 1);
+}
+
+#[test]
+fn test_register_template_version_bumps() {
+    let (env, gov_id, _at, _ec, admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+
+    client.register_template_version(&admin, &ProposalTemplate::FeeChange, &2);
+    assert_eq!(client.get_template_version(&ProposalTemplate::FeeChange), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Parameter-bounds validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validate_template_params() {
+    let (env, gov_id, _at, _ec, _admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+
+    // FeeChange caps fee bps at 1000; 500 is valid, 2000 is not.
+    assert!(client.validate_template_params(
+        &ProposalTemplate::FeeChange,
+        &1,
+        &500,
+        &0,
+        &None
+    ));
+    assert!(!client.validate_template_params(
+        &ProposalTemplate::FeeChange,
+        &1,
+        &2000,
+        &0,
+        &None
+    ));
+
+    // TreasurySpend requires a target address.
+    let recipient = Address::generate(&env);
+    assert!(client.validate_template_params(
+        &ProposalTemplate::TreasurySpend,
+        &1,
+        &0,
+        &1_000,
+        &Some(recipient)
+    ));
+    assert!(!client.validate_template_params(
+        &ProposalTemplate::TreasurySpend,
+        &1,
+        &0,
+        &1_000,
+        &None
+    ));
+
+    // Wrong version fails validation.
+    assert!(!client.validate_template_params(
+        &ProposalTemplate::FeeChange,
+        &99,
+        &500,
+        &0,
+        &None
+    ));
+}
+
+#[test]
+#[should_panic(expected = "template parameters out of bounds")]
+fn test_create_from_template_rejects_out_of_bounds() {
+    let (env, gov_id, at_id, ec_id, _admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+    let proposer = Address::generate(&env);
+    mint(&env, &at_id, &ec_id, &proposer, 200);
+
+    // 2000 bps exceeds the FeeChange ceiling of 1000.
+    client.create_proposal_from_template(
+        &proposer,
+        &ProposalTemplate::FeeChange,
+        &1,
+        &2000,
+        &0,
+        &None,
+        &String::from_str(&env, "raise fee"),
+        &3600,
+    );
+}
+
+#[test]
+#[should_panic(expected = "template requires a target address")]
+fn test_create_from_template_requires_target() {
+    let (env, gov_id, at_id, ec_id, _admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+    let proposer = Address::generate(&env);
+    mint(&env, &at_id, &ec_id, &proposer, 200);
+
+    client.create_proposal_from_template(
+        &proposer,
+        &ProposalTemplate::TreasurySpend,
+        &1,
+        &0,
+        &1_000,
+        &None,
+        &String::from_str(&env, "spend treasury"),
+        &3600,
+    );
+}
+
+#[test]
+#[should_panic(expected = "unsupported template version")]
+fn test_create_from_template_rejects_stale_version() {
+    let (env, gov_id, at_id, ec_id, admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+    let proposer = Address::generate(&env);
+    mint(&env, &at_id, &ec_id, &proposer, 200);
+
+    // Bump to v2; a proposal built against v1 must be rejected.
+    client.register_template_version(&admin, &ProposalTemplate::FeeChange, &2);
+    client.create_proposal_from_template(
+        &proposer,
+        &ProposalTemplate::FeeChange,
+        &1,
+        &500,
+        &0,
+        &None,
+        &String::from_str(&env, "stale"),
+        &3600,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end template proposal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_create_and_pass_add_asset_template() {
+    let (env, gov_id, at_id, ec_id, _admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    mint(&env, &at_id, &ec_id, &proposer, 200);
+    mint(&env, &at_id, &ec_id, &voter, 150);
+
+    // AddAsset template: param_u64 is the asset id to approve.
+    let pid = client.create_proposal_from_template(
+        &proposer,
+        &ProposalTemplate::AddAsset,
+        &1,
+        &77,
+        &0,
+        &None,
+        &String::from_str(&env, "list asset 77"),
+        &3600,
+    );
+
+    // Template metadata is recorded alongside the proposal.
+    let meta = client.get_template_proposal(&pid).unwrap();
+    assert_eq!(meta.template, ProposalTemplate::AddAsset);
+    assert_eq!(meta.param_u64, 77);
+    assert_eq!(meta.version, 1);
+
+    // Vote it through; on tally the asset id is approved.
+    client.vote(&voter, &pid, &true);
+    env.ledger().with_mut(|li| li.timestamp += 3601);
+    client.tally_execute(&pid);
+
+    let proposal = client.get_proposal(&pid).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Passed);
+    assert!(client.is_approved(&77));
+}
+
+#[test]
+fn test_text_proposal_template() {
+    let (env, gov_id, at_id, ec_id, _admin) = setup();
+    let client = GovernanceClient::new(&env, &gov_id);
+
+    let proposer = Address::generate(&env);
+    mint(&env, &at_id, &ec_id, &proposer, 200);
+
+    let pid = client.create_proposal_from_template(
+        &proposer,
+        &ProposalTemplate::TextProposal,
+        &1,
+        &0,
+        &0,
+        &None,
+        &String::from_str(&env, "signal: thanks to contributors"),
+        &3600,
+    );
+
+    let meta = client.get_template_proposal(&pid).unwrap();
+    assert_eq!(meta.template, ProposalTemplate::TextProposal);
+}

--- a/contracts/tests/liquidity_test.rs
+++ b/contracts/tests/liquidity_test.rs
@@ -1,0 +1,186 @@
+// Integration tests for liquidity-pool fee tiers (Issue #209).
+//
+// Covers tier selection at pool creation, fee-tier migration, proportional
+// fee distribution to LPs, and the tier-recommendation helper.
+
+#![cfg(test)]
+
+extern crate kor_assetforge_contracts;
+
+use kor_assetforge_contracts::liquidity_pool::{FeeTier, LiquidityPool, LiquidityPoolClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+fn setup(env: &Env) -> (LiquidityPoolClient, Address) {
+    let id = env.register_contract(None, LiquidityPool);
+    let client = LiquidityPoolClient::new(env, &id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// Tier selection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_create_pool_with_each_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let low = client.create_pool_with_tier(&creator, &1, &2, &FeeTier::Low);
+    let med = client.create_pool_with_tier(&creator, &3, &4, &FeeTier::Medium);
+    let high = client.create_pool_with_tier(&creator, &5, &6, &FeeTier::High);
+
+    assert_eq!(client.get_pool(&low).unwrap().fee_bps, 5);
+    assert_eq!(client.get_pool(&low).unwrap().fee_tier, FeeTier::Low);
+    assert_eq!(client.get_pool(&med).unwrap().fee_bps, 30);
+    assert_eq!(client.get_pool(&high).unwrap().fee_bps, 100);
+    assert_eq!(client.get_pool(&high).unwrap().fee_tier, FeeTier::High);
+}
+
+#[test]
+fn test_legacy_create_pool_maps_to_nearest_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let creator = Address::generate(&env);
+
+    // 5 bps -> Low, 30 bps -> Medium, 100 bps -> High.
+    let p_low = client.create_pool(&creator, &1, &2, &5);
+    let p_med = client.create_pool(&creator, &3, &4, &30);
+    let p_high = client.create_pool(&creator, &5, &6, &100);
+
+    assert_eq!(client.get_pool(&p_low).unwrap().fee_tier, FeeTier::Low);
+    assert_eq!(client.get_pool(&p_med).unwrap().fee_tier, FeeTier::Medium);
+    assert_eq!(client.get_pool(&p_high).unwrap().fee_tier, FeeTier::High);
+}
+
+// ---------------------------------------------------------------------------
+// Fee-tier migration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_migrate_fee_tier_by_creator() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&creator, &1, &2, &FeeTier::Medium);
+    client.migrate_fee_tier(&creator, &pool_id, &FeeTier::High);
+
+    let pool = client.get_pool(&pool_id).unwrap();
+    assert_eq!(pool.fee_tier, FeeTier::High);
+    assert_eq!(pool.fee_bps, 100);
+}
+
+#[test]
+fn test_migrate_fee_tier_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&creator, &1, &2, &FeeTier::High);
+    client.migrate_fee_tier(&admin, &pool_id, &FeeTier::Low);
+
+    assert_eq!(client.get_pool(&pool_id).unwrap().fee_bps, 5);
+}
+
+#[test]
+#[should_panic(expected = "only pool creator or admin")]
+fn test_migrate_fee_tier_rejects_stranger() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    let creator = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&creator, &1, &2, &FeeTier::Medium);
+    client.migrate_fee_tier(&stranger, &pool_id, &FeeTier::High);
+}
+
+// ---------------------------------------------------------------------------
+// Proportional fee distribution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fees_distributed_proportionally() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let lp1 = Address::generate(&env);
+    let lp2 = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    // 0.30% tier so the fee on a 1_000_000 swap is exactly 3000.
+    let pool_id = client.create_pool_with_tier(&lp1, &1, &2, &FeeTier::Medium);
+
+    // Two providers with equal stakes -> each owns half the pool.
+    client.add_liquidity(&lp1, &pool_id, &10_000_000, &10_000_000);
+    client.add_liquidity(&lp2, &pool_id, &10_000_000, &10_000_000);
+
+    // Swap asset_a -> asset_b. Fee accrues in asset_a.
+    let result = client.swap(&trader, &pool_id, &1, &1_000_000, &0);
+    assert_eq!(result.fee_amount, 3000);
+
+    let (p1_a, _p1_b) = client.pending_fees(&pool_id, &lp1);
+    let (p2_a, _p2_b) = client.pending_fees(&pool_id, &lp2);
+
+    // Equal stake -> equal split of the 3000 fee.
+    assert_eq!(p1_a, 1500);
+    assert_eq!(p2_a, 1500);
+
+    // Claiming pays out and zeroes the pending balance.
+    let (claimed_a, _claimed_b) = client.claim_fees(&lp1, &pool_id);
+    assert_eq!(claimed_a, 1500);
+    assert_eq!(client.pending_fees(&pool_id, &lp1), (0, 0));
+}
+
+#[test]
+fn test_fees_track_changing_share() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let lp1 = Address::generate(&env);
+    let lp2 = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&lp1, &1, &2, &FeeTier::Medium);
+
+    // lp1 is the sole provider for the first swap -> earns the whole fee.
+    client.add_liquidity(&lp1, &pool_id, &10_000_000, &10_000_000);
+    client.swap(&trader, &pool_id, &1, &1_000_000, &0);
+
+    let (p1_after_first, _) = client.pending_fees(&pool_id, &lp1);
+    assert_eq!(p1_after_first, 3000);
+
+    // lp2 joins; subsequent fees split, but lp2 never earns the earlier fee.
+    client.add_liquidity(&lp2, &pool_id, &10_000_000, &10_000_000);
+    let (p2_initial, _) = client.pending_fees(&pool_id, &lp2);
+    assert_eq!(p2_initial, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Tier recommendation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_recommend_tier() {
+    let env = Env::default();
+    let (client, _) = setup(&env);
+
+    // High volatility -> High tier.
+    assert_eq!(client.recommend_tier(&600, &0), FeeTier::High);
+    // Low volatility + deep liquidity -> Low tier.
+    assert_eq!(client.recommend_tier(&10, &2_000_000), FeeTier::Low);
+    // Low volatility but shallow liquidity -> Medium tier.
+    assert_eq!(client.recommend_tier(&10, &100), FeeTier::Medium);
+    // Moderate volatility -> Medium tier.
+    assert_eq!(client.recommend_tier(&200, &5_000_000), FeeTier::Medium);
+}

--- a/contracts/tests/security_test.rs
+++ b/contracts/tests/security_test.rs
@@ -1,0 +1,209 @@
+// Security / flash-loan protection tests (Issue #210).
+//
+// Covers the TWAP oracle, per-block trade limits, deposit/withdraw cooldowns
+// and price-deviation detection in the liquidity pool, plus the per-block
+// purchase limit in the marketplace.
+
+#![cfg(test)]
+
+extern crate kor_assetforge_contracts;
+
+use kor_assetforge_contracts::emergency_control::{EmergencyControl, EmergencyControlClient};
+use kor_assetforge_contracts::liquidity_pool::{FeeTier, LiquidityPool, LiquidityPoolClient};
+use kor_assetforge_contracts::marketplace::{Marketplace, MarketplaceClient};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env};
+
+fn setup_pool(env: &Env) -> (LiquidityPoolClient, Address) {
+    let id = env.register_contract(None, LiquidityPool);
+    let client = LiquidityPoolClient::new(env, &id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// TWAP oracle
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_twap_tracks_average_price() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup_pool(&env);
+    let lp = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&lp, &1, &2, &FeeTier::Medium);
+    client.add_liquidity(&lp, &pool_id, &1_000_000, &1_000_000);
+
+    // 1:1 reserves -> spot price == PRICE_SCALE (1e7).
+    assert_eq!(client.get_spot_price(&pool_id), 10_000_000);
+
+    // Anchor the TWAP window, then let time pass with no trades.
+    client.snapshot_twap(&pool_id);
+    env.ledger().with_mut(|li| li.timestamp += 100);
+
+    // With a flat price over the window the TWAP equals the spot price.
+    assert_eq!(client.get_twap(&pool_id), 10_000_000);
+}
+
+// ---------------------------------------------------------------------------
+// Per-block trade limit (liquidity pool)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "per-block trade limit exceeded")]
+fn test_pool_per_block_trade_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_pool(&env);
+    let lp = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&lp, &1, &2, &FeeTier::Medium);
+    client.add_liquidity(&lp, &pool_id, &100_000_000, &100_000_000);
+
+    // Allow at most 2 swaps per block.
+    client.set_guard_config(&admin, &2, &0, &0);
+
+    client.swap(&trader, &pool_id, &1, &10_000, &0);
+    client.swap(&trader, &pool_id, &1, &10_000, &0);
+    // Third swap in the same ledger must revert.
+    client.swap(&trader, &pool_id, &1, &10_000, &0);
+}
+
+#[test]
+fn test_pool_trade_limit_resets_next_block() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_pool(&env);
+    let lp = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&lp, &1, &2, &FeeTier::Medium);
+    client.add_liquidity(&lp, &pool_id, &100_000_000, &100_000_000);
+    client.set_guard_config(&admin, &1, &0, &0);
+
+    client.swap(&trader, &pool_id, &1, &10_000, &0);
+    // Advance to the next ledger; the per-block counter resets.
+    env.ledger().with_mut(|li| li.sequence_number += 1);
+    client.swap(&trader, &pool_id, &1, &10_000, &0);
+}
+
+// ---------------------------------------------------------------------------
+// Deposit / withdraw cooldown
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "deposit/withdraw cooldown active")]
+fn test_withdraw_cooldown_blocks_immediate_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_pool(&env);
+    let lp = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&lp, &1, &2, &FeeTier::Medium);
+    client.set_guard_config(&admin, &0, &3600, &0);
+
+    let lp_tokens = client.add_liquidity(&lp, &pool_id, &1_000_000, &1_000_000);
+    // Withdrawing within the cooldown window must revert.
+    client.remove_liquidity(&lp, &pool_id, &lp_tokens);
+}
+
+#[test]
+fn test_withdraw_allowed_after_cooldown() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_pool(&env);
+    let lp = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&lp, &1, &2, &FeeTier::Medium);
+    client.set_guard_config(&admin, &0, &3600, &0);
+
+    let lp_tokens = client.add_liquidity(&lp, &pool_id, &1_000_000, &1_000_000);
+    env.ledger().with_mut(|li| li.timestamp += 3601);
+
+    let (a, b) = client.remove_liquidity(&lp, &pool_id, &lp_tokens);
+    assert!(a > 0 && b > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Price deviation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_large_swap_creates_price_deviation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_pool(&env);
+    let lp = Address::generate(&env);
+    let trader = Address::generate(&env);
+
+    let pool_id = client.create_pool_with_tier(&lp, &1, &2, &FeeTier::Medium);
+    client.add_liquidity(&lp, &pool_id, &1_000_000, &1_000_000);
+
+    // Enable deviation alerts (200 bps threshold).
+    client.set_guard_config(&admin, &0, &0, &200);
+
+    // Anchor TWAP, let time pass so the window has weight at the old price.
+    client.snapshot_twap(&pool_id);
+    env.ledger().with_mut(|li| li.timestamp += 100);
+
+    // A swap consuming a third of the pool moves the spot price sharply.
+    client.swap(&trader, &pool_id, &1, &500_000, &0);
+
+    // Spot now diverges far from the (flat) TWAP.
+    let deviation = client.price_deviation_bps(&pool_id);
+    assert!(deviation > 1_000, "expected large deviation, got {}", deviation);
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace per-block purchase limit
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "per-block trade limit exceeded")]
+fn test_marketplace_per_block_purchase_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ec_id = env.register_contract(None, EmergencyControl);
+    let ec_client = EmergencyControlClient::new(&env, &ec_id);
+    let admin = Address::generate(&env);
+    ec_client.initialize(&admin);
+
+    let mp_id = env.register_contract(None, Marketplace);
+    let mp_client = MarketplaceClient::new(&env, &mp_id);
+    mp_client.initialize(&admin);
+
+    // Allow a single purchase per block per buyer.
+    mp_client.configure_flash_loan_guard(&admin, &1, &0);
+
+    let buyer = Address::generate(&env);
+    let asset_id = 1u64;
+
+    mp_client.purchase(&buyer, &1, &100, &asset_id, &ec_id);
+    // Second purchase in the same ledger must revert.
+    mp_client.purchase(&buyer, &1, &100, &asset_id, &ec_id);
+}
+
+#[test]
+fn test_marketplace_guard_defaults_permissive() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ec_id = env.register_contract(None, EmergencyControl);
+    let ec_client = EmergencyControlClient::new(&env, &ec_id);
+    let admin = Address::generate(&env);
+    ec_client.initialize(&admin);
+
+    let mp_id = env.register_contract(None, Marketplace);
+    let mp_client = MarketplaceClient::new(&env, &mp_id);
+    mp_client.initialize(&admin);
+
+    let buyer = Address::generate(&env);
+    // With no guard configured, repeated purchases are unrestricted.
+    assert!(mp_client.purchase(&buyer, &1, &100, &1, &ec_id));
+    assert!(mp_client.purchase(&buyer, &1, &100, &1, &ec_id));
+    assert!(mp_client.purchase(&buyer, &1, &100, &1, &ec_id));
+}


### PR DESCRIPTION
## Summary

Implements three Stellar Wave issues for the Soroban contracts, each as an atomic commit:

- **#209 — Configurable fee tiers for liquidity pools**
  - `FeeTier` enum: `Low` (0.05%), `Medium` (0.30%), `High` (1.00%)
  - `create_pool_with_tier` for tier selection; `create_pool` kept for backward compatibility (maps a raw fee to the nearest tier)
  - Per-LP fee accumulators distribute swap fees proportionally; `claim_fees` / `pending_fees`
  - `migrate_fee_tier` (creator or admin); `recommend_tier` based on volatility + liquidity depth

- **#210 — Flash loan attack protection**
  - Pool: TWAP oracle (cumulative price + `snapshot_twap` / `get_twap`), per-block trade limits, deposit/withdraw cooldowns, spot-vs-TWAP deviation alerts (`set_guard_config`)
  - Marketplace: per-buyer per-block purchase limit (`configure_flash_loan_guard`) and `purchase_guarded` oracle deviation check

- **#211 — Pre-defined governance proposal templates**
  - `ProposalTemplate` with 10 common templates, per-template parameter bounds checking, template versioning, and `create_proposal_from_template`

## Tests

Added `contracts/tests/liquidity_test.rs`, `security_test.rs`, `governance_test.rs` — **25 new tests, all passing** (`cargo test`), plus existing module unit tests.

## Note on the base branch

`main` did not compile when this branch was cut (the contract crate is not built in CI): `staking_rewards.rs` referenced an undefined `StakingDataKey::PoolCapacity` variant, and `dispute_resolution.rs` had a half-finished `Option<DisputeOutcome>` → `DisputeOutcome::None` refactor. A separate `chore:` commit adds the missing variant and completes the `None` handling so the branch builds. It is unrelated to the three issues and can be dropped if you prefer to fix it elsewhere.

Closes #209
Closes #210
Closes #211
