### PR TITLE
feat: Frontend UI enhancements — Toasts, Wallet Modal, Trading Interface & Activity Feed

### DIFF
--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+import { ActivityFeed } from "@/components/ActivityFeed";
+import { Header } from "@/components/Header";
+import type { StellarWallet } from "@/lib/stellar";
+
+export default function ActivityPage() {
+  const [wallet, setWallet] = useState<StellarWallet | undefined>();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header
+        wallet={wallet}
+        onWalletConnected={setWallet}
+        onWalletDisconnected={() => setWallet(undefined)}
+      />
+
+      <main id="main-content" className="container mx-auto max-w-3xl px-4 py-8">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold">Activity</h1>
+          <p className="mt-1 text-muted-foreground">
+            Live trades, listings, proposals and verifications from across the
+            platform.
+          </p>
+        </div>
+
+        <ActivityFeed />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { Toaster } from "@/components/ui/sonner";
+import { ToastContainer } from "@/components/ui/Toast";
 import { OnboardingProvider } from "@/components/onboarding/OnboardingProvider";
 
 const geistSans = Geist({
@@ -47,7 +47,7 @@ export default async function RootLayout({
             </OnboardingProvider>
           </ErrorBoundary>
         </NextIntlClientProvider>
-        <Toaster />
+        <ToastContainer />
       </body>
     </html>
   );

--- a/frontend/src/app/trade/[id]/page.tsx
+++ b/frontend/src/app/trade/[id]/page.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { ArrowLeft, RefreshCw, TriangleAlert } from "lucide-react";
+
+import { Header } from "@/components/Header";
+import { OrderBook } from "@/components/OrderBook";
+import { OrderForm, type OrderFormHandle } from "@/components/OrderForm";
+import { WalletConnect } from "@/components/WalletConnect";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton, SkeletonList } from "@/components/ui/skeleton";
+import { assetApi, type AssetDetail } from "@/lib/asset-api";
+import type { StellarWallet } from "@/lib/stellar";
+import {
+  subscribeToOrderBook,
+  tradingApi,
+  type OrderBookSnapshot,
+  type OrderSide,
+  type RecentTrade,
+} from "@/lib/trading";
+import type { WSStatus } from "@/lib/websocket";
+import { cn, formatAmount, formatCurrency } from "@/lib/utils";
+
+/** How often the book is re-fetched when the WebSocket isn't delivering. */
+const POLL_INTERVAL = 15_000;
+
+/** Minimal stand-in so the ticket stays usable when the assets API is down. */
+function sampleAsset(assetId: string): AssetDetail {
+  return {
+    id: assetId,
+    code: assetId.slice(0, 4).toUpperCase() || "ASSET",
+    issuer: "",
+    name: "Sample asset",
+    description: "",
+    totalSupply: "0",
+    decimals: 7,
+    price: 100,
+    priceChange24h: 0,
+    marketCap: 0,
+    volume24h: 0,
+    allTimeHigh: 0,
+    allTimeLow: 0,
+    createdAt: Date.now(),
+    verified: false,
+    documents: [],
+    metadata: { category: "", location: "", condition: "", tags: [] },
+  };
+}
+
+function LiveIndicator({ status }: { status: WSStatus }) {
+  const label =
+    status === "connected"
+      ? "Live"
+      : status === "connecting"
+        ? "Connecting…"
+        : "Polling";
+
+  return (
+    <span
+      role="status"
+      className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "size-1.5 rounded-full",
+          status === "connected"
+            ? "bg-emerald-500"
+            : status === "connecting"
+              ? "animate-pulse bg-amber-400"
+              : "bg-muted-foreground/50",
+        )}
+      />
+      {label}
+    </span>
+  );
+}
+
+export default function TradePage() {
+  const params = useParams();
+  const assetId = String(params.id ?? "");
+
+  const [wallet, setWallet] = React.useState<StellarWallet | undefined>();
+  const [asset, setAsset] = React.useState<AssetDetail | null>(null);
+  const [book, setBook] = React.useState<OrderBookSnapshot | null>(null);
+  const [trades, setTrades] = React.useState<RecentTrade[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
+  const [assetError, setAssetError] = React.useState<string | null>(null);
+  const [wsStatus, setWsStatus] = React.useState<WSStatus>("disconnected");
+
+  const formRef = React.useRef<OrderFormHandle>(null);
+
+  const load = React.useCallback(async () => {
+    let detail: AssetDetail;
+    let error: string | null = null;
+
+    try {
+      detail = await assetApi.getAssetDetail(assetId);
+    } catch {
+      // The marketplace API isn't reachable — keep the ticket usable with
+      // clearly-labelled sample pricing instead of a dead page.
+      detail = sampleAsset(assetId);
+      error =
+        "Live asset data is unavailable right now. Prices below are sample data.";
+    }
+
+    const [nextBook, nextTrades] = await Promise.all([
+      tradingApi.getOrderBook(assetId, detail.price),
+      tradingApi.getRecentTrades(assetId),
+    ]);
+
+    setAsset(detail);
+    setAssetError(error);
+    setBook(nextBook);
+    setTrades(nextTrades);
+    setIsLoading(false);
+  }, [assetId]);
+
+  // Initial load plus a polling fallback, so the book stays fresh even without
+  // a WebSocket server.
+  React.useEffect(() => {
+    if (!assetId) return;
+
+    // The first load is queued as a task so the effect body itself performs no
+    // state updates (see react-hooks/set-state-in-effect).
+    const initial = window.setTimeout(load, 0);
+    const timer = window.setInterval(load, POLL_INTERVAL);
+
+    return () => {
+      window.clearTimeout(initial);
+      window.clearInterval(timer);
+    };
+  }, [assetId, load]);
+
+  // Live book updates when the platform WebSocket is available.
+  React.useEffect(() => {
+    if (!assetId) return;
+    return subscribeToOrderBook(assetId, setBook, setWsStatus);
+  }, [assetId]);
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    await load();
+    setIsRefreshing(false);
+  };
+
+  const handleSelectPrice = (price: number, side: OrderSide) => {
+    formRef.current?.applyPrice(price, side);
+  };
+
+  const priceChange = asset?.priceChange24h ?? 0;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header
+        wallet={wallet}
+        onWalletConnected={setWallet}
+        onWalletDisconnected={() => setWallet(undefined)}
+      />
+
+      <main id="main-content" className="container mx-auto max-w-6xl px-4 py-8">
+        <Link
+          href={`/assets/${assetId}`}
+          className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Back to asset
+        </Link>
+
+        {/* ── Asset summary ─────────────────────────────────────────────── */}
+        <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            {isLoading ? (
+              <div className="space-y-2">
+                <Skeleton className="h-8 w-56" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+            ) : (
+              <>
+                <div className="flex flex-wrap items-center gap-2">
+                  <h1 className="text-3xl font-bold">{asset?.name}</h1>
+                  <Badge variant="secondary">{asset?.code}</Badge>
+                  {asset?.verified && <Badge>Verified</Badge>}
+                </div>
+                <p className="mt-1 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+                  <span className="font-mono text-base text-foreground">
+                    {formatCurrency(asset?.price ?? 0)}
+                  </span>
+                  <span
+                    className={cn(
+                      "font-medium",
+                      priceChange >= 0
+                        ? "text-emerald-600 dark:text-emerald-400"
+                        : "text-destructive",
+                    )}
+                  >
+                    {priceChange >= 0 ? "+" : ""}
+                    {priceChange.toFixed(2)}% 24h
+                  </span>
+                  <LiveIndicator status={wsStatus} />
+                </p>
+              </>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              aria-busy={isRefreshing}
+            >
+              <RefreshCw
+                className={cn("size-3.5", isRefreshing && "animate-spin")}
+                aria-hidden="true"
+              />
+              Refresh
+            </Button>
+            <WalletConnect
+              variant="button"
+              wallet={wallet}
+              onWalletConnected={setWallet}
+              onWalletDisconnected={() => setWallet(undefined)}
+            />
+          </div>
+        </div>
+
+        {(assetError || book?.isSample) && !isLoading && (
+          <div
+            role="status"
+            className="mb-6 flex items-start gap-2 rounded-lg bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400"
+          >
+            <TriangleAlert className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            <p>
+              {assetError ??
+                "The marketplace order book API is unavailable — showing sample depth so the interface stays explorable."}
+            </p>
+          </div>
+        )}
+
+        {/* ── Book + ticket ─────────────────────────────────────────────── */}
+        <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
+          <div className="space-y-6">
+            <OrderBook
+              book={book}
+              isLoading={isLoading}
+              onRetry={handleRefresh}
+              onSelectPrice={handleSelectPrice}
+              assetCode={asset?.code ?? ""}
+            />
+
+            <Card>
+              <CardHeader className="border-b">
+                <CardTitle>Recent trades</CardTitle>
+                <CardDescription>
+                  The latest fills for this asset
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {isLoading ? (
+                  <SkeletonList rows={3} />
+                ) : trades.length === 0 ? (
+                  <p className="py-6 text-center text-sm text-muted-foreground">
+                    No trades recorded yet.
+                  </p>
+                ) : (
+                  <ul className="divide-y">
+                    {trades.map((trade) => (
+                      <li
+                        key={trade.id}
+                        className="flex items-center justify-between gap-4 py-2 text-sm"
+                      >
+                        <span
+                          className={cn(
+                            "font-medium",
+                            trade.side === "buy"
+                              ? "text-emerald-600 dark:text-emerald-400"
+                              : "text-destructive",
+                          )}
+                        >
+                          {trade.side === "buy" ? "Buy" : "Sell"}
+                        </span>
+                        <span className="font-mono text-xs">
+                          {formatAmount(trade.amount, 2)} @{" "}
+                          {formatCurrency(trade.price)}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {new Date(trade.timestamp).toLocaleTimeString()}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="lg:sticky lg:top-6 lg:self-start">
+            <OrderForm
+              ref={formRef}
+              assetId={assetId}
+              assetCode={asset?.code ?? ""}
+              assetName={asset?.name}
+              book={book}
+              wallet={wallet}
+              onSubmitted={handleRefresh}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import {
+  ArrowLeftRight,
+  BadgeCheck,
+  Coins,
+  FileText,
+  Lock,
+  PieChart,
+  RefreshCw,
+  Tag,
+  TriangleAlert,
+  Vote,
+} from "lucide-react";
+
+import { InfiniteScroll } from "@/components/InfiniteScroll";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { SkeletonList } from "@/components/ui/skeleton";
+import {
+  useActivityFeed,
+  type ActivityEvent,
+  type ActivityType,
+} from "@/hooks/useActivityFeed";
+import { cn, formatAmount, truncateAddress } from "@/lib/utils";
+
+interface ActivityFeedProps {
+  /** Limit the feed to one asset. */
+  assetId?: string;
+  /** Show the event-type filter row (default: true). */
+  showFilters?: boolean;
+  /** Subscribe to live WebSocket updates (default: true). */
+  live?: boolean;
+  pageSize?: number;
+  className?: string;
+}
+
+const EVENT_META: Record<
+  ActivityType,
+  { label: string; icon: React.ElementType; className: string }
+> = {
+  trade: {
+    label: "Trades",
+    icon: ArrowLeftRight,
+    className: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+  },
+  listing: {
+    label: "Listings",
+    icon: Tag,
+    className: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+  },
+  proposal: {
+    label: "Proposals",
+    icon: FileText,
+    className: "bg-violet-500/15 text-violet-600 dark:text-violet-400",
+  },
+  vote: {
+    label: "Votes",
+    icon: Vote,
+    className: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  },
+  mint: {
+    label: "Mints",
+    icon: Coins,
+    className: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",
+  },
+  fractionalize: {
+    label: "Fractionalisations",
+    icon: PieChart,
+    className: "bg-teal-500/15 text-teal-600 dark:text-teal-400",
+  },
+  escrow: {
+    label: "Escrow",
+    icon: Lock,
+    className: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
+  },
+  verification: {
+    label: "Verifications",
+    icon: BadgeCheck,
+    className: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400",
+  },
+};
+
+const FILTERABLE_TYPES = Object.keys(EVENT_META) as ActivityType[];
+
+/** Compact relative time ("just now", "12m", "3h", "5d"). */
+function formatRelativeTime(timestamp: number): string {
+  const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+
+  if (seconds < 45) return "just now";
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
+  if (seconds < 86_400) return `${Math.round(seconds / 3600)}h ago`;
+  return `${Math.round(seconds / 86_400)}d ago`;
+}
+
+function ActivityRow({ event }: { event: ActivityEvent }) {
+  const meta = EVENT_META[event.type];
+  const Icon = meta?.icon ?? FileText;
+
+  const row = (
+    <div className="flex items-start gap-3 rounded-lg p-2 transition-colors hover:bg-muted/60">
+      <span
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-lg",
+          meta?.className,
+        )}
+        aria-hidden="true"
+      >
+        <Icon className="size-4" />
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium leading-snug">{event.title}</p>
+        {event.description && (
+          <p className="truncate text-xs text-muted-foreground">
+            {event.description}
+          </p>
+        )}
+        {event.actor && (
+          <p className="mt-0.5 font-mono text-[0.7rem] text-muted-foreground">
+            {truncateAddress(event.actor)}
+          </p>
+        )}
+      </div>
+
+      <div className="shrink-0 text-right">
+        <time
+          dateTime={new Date(event.timestamp).toISOString()}
+          className="text-xs text-muted-foreground"
+        >
+          {formatRelativeTime(event.timestamp)}
+        </time>
+        {event.amount !== undefined && (
+          <p className="font-mono text-xs">{formatAmount(event.amount, 2)}</p>
+        )}
+      </div>
+    </div>
+  );
+
+  // Events tied to an asset link straight to its detail page.
+  return event.assetId ? (
+    <Link
+      href={`/assets/${event.assetId}`}
+      className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+    >
+      {row}
+    </Link>
+  ) : (
+    row
+  );
+}
+
+/**
+ * Platform activity feed: trades, listings, proposals and other events grouped
+ * by day, filterable by type, with infinite scroll and live WebSocket updates.
+ */
+export function ActivityFeed({
+  assetId,
+  showFilters = true,
+  live = true,
+  pageSize = 20,
+  className,
+}: ActivityFeedProps) {
+  const [selectedTypes, setSelectedTypes] = React.useState<ActivityType[]>([]);
+
+  const {
+    groups,
+    events,
+    isLoading,
+    isLoadingMore,
+    error,
+    hasMore,
+    isSample,
+    liveStatus,
+    loadMore,
+    refresh,
+  } = useActivityFeed({ types: selectedTypes, assetId, pageSize, live });
+
+  const toggleType = (type: ActivityType) => {
+    setSelectedTypes((current) =>
+      current.includes(type)
+        ? current.filter((value) => value !== type)
+        : [...current, type],
+    );
+  };
+
+  const isEmpty = !isLoading && events.length === 0;
+
+  return (
+    <Card className={className}>
+      <CardHeader className="border-b">
+        <CardTitle className="flex items-center gap-2">
+          Activity
+          {live && (
+            <span
+              role="status"
+              className="inline-flex items-center gap-1.5 text-xs font-normal text-muted-foreground"
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "size-1.5 rounded-full",
+                  liveStatus === "connected"
+                    ? "bg-emerald-500"
+                    : liveStatus === "connecting"
+                      ? "animate-pulse bg-amber-400"
+                      : "bg-muted-foreground/50",
+                )}
+              />
+              {liveStatus === "connected" ? "Live" : "Offline"}
+            </span>
+          )}
+        </CardTitle>
+        <CardDescription>
+          {assetId
+            ? "Recent events for this asset"
+            : "What's happening across the platform"}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {showFilters && (
+          <div
+            role="group"
+            aria-label="Filter activity by type"
+            className="flex flex-wrap gap-1.5"
+          >
+            <button
+              type="button"
+              onClick={() => setSelectedTypes([])}
+              aria-pressed={selectedTypes.length === 0}
+              className={cn(
+                "rounded-full px-2.5 py-1 text-xs font-medium ring-1 transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                selectedTypes.length === 0
+                  ? "bg-primary text-primary-foreground ring-transparent"
+                  : "ring-foreground/10 hover:bg-muted",
+              )}
+            >
+              All
+            </button>
+
+            {FILTERABLE_TYPES.map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => toggleType(type)}
+                aria-pressed={selectedTypes.includes(type)}
+                className={cn(
+                  "rounded-full px-2.5 py-1 text-xs font-medium ring-1 transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                  selectedTypes.includes(type)
+                    ? "bg-primary text-primary-foreground ring-transparent"
+                    : "ring-foreground/10 hover:bg-muted",
+                )}
+              >
+                {EVENT_META[type].label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {isSample && !isLoading && (
+          <p className="flex items-start gap-2 rounded-lg bg-amber-500/10 p-2.5 text-xs text-amber-700 dark:text-amber-400">
+            <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+            The activity API is unavailable — showing sample events.
+          </p>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="flex items-center justify-between gap-3 rounded-lg bg-destructive/10 p-2.5 text-xs text-destructive"
+          >
+            <span>{error}</span>
+            <Button variant="ghost" size="xs" onClick={refresh}>
+              <RefreshCw className="size-3" aria-hidden="true" />
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {isLoading && <SkeletonList rows={5} />}
+
+        {isEmpty && (
+          <div className="py-10 text-center">
+            <p className="text-sm text-muted-foreground">
+              No activity to show
+              {selectedTypes.length > 0 ? " for these filters" : " yet"}.
+            </p>
+            {selectedTypes.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-3"
+                onClick={() => setSelectedTypes([])}
+              >
+                Clear filters
+              </Button>
+            )}
+          </div>
+        )}
+
+        {!isLoading && !isEmpty && (
+          <InfiniteScroll
+            loadMore={loadMore}
+            hasMore={hasMore}
+            isLoading={isLoadingMore}
+            endMessage="You're all caught up."
+          >
+            <div className="space-y-4">
+              {groups.map((group) => (
+                <section key={group.label}>
+                  <h3 className="sticky top-0 z-10 bg-card/95 py-1 text-xs font-medium text-muted-foreground backdrop-blur">
+                    {group.label}
+                  </h3>
+                  <div className="space-y-0.5">
+                    {group.events.map((event) => (
+                      <ActivityRow key={event.id} event={event} />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </InfiniteScroll>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/OrderBook.tsx
+++ b/frontend/src/components/OrderBook.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { RefreshCw, TriangleAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { SkeletonTable } from "@/components/ui/skeleton";
+import {
+  getSpread,
+  withCumulativeTotals,
+  type OrderBookSnapshot,
+  type OrderSide,
+} from "@/lib/trading";
+import { cn, formatAmount } from "@/lib/utils";
+
+interface OrderBookProps {
+  book: OrderBookSnapshot | null;
+  isLoading: boolean;
+  error?: string | null;
+  /** Retry handler shown with the error state. */
+  onRetry?: () => void;
+  /** Clicking a level pushes its price into the order form. */
+  onSelectPrice?: (price: number, side: OrderSide) => void;
+  assetCode?: string;
+  /** Levels rendered per side (default: 8). */
+  maxLevels?: number;
+  className?: string;
+}
+
+function LevelRow({
+  price,
+  amount,
+  total,
+  depth,
+  side,
+  onSelect,
+}: {
+  price: number;
+  amount: number;
+  total: number;
+  depth: number;
+  side: OrderSide;
+  onSelect?: () => void;
+}) {
+  const isBid = side === "buy";
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={!onSelect}
+      // The depth bar is a background layer so the numbers stay readable.
+      className="relative grid w-full grid-cols-3 gap-2 px-2 py-1 text-right font-mono text-xs transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none"
+      aria-label={`${isBid ? "Bid" : "Ask"} ${formatAmount(amount, 2)} at ${formatAmount(price, 4)}`}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-y-0 right-0 -z-0",
+          isBid ? "bg-emerald-500/10" : "bg-destructive/10",
+        )}
+        style={{ width: `${Math.max(depth * 100, 2)}%` }}
+      />
+      <span
+        className={cn(
+          "z-10 text-left",
+          isBid
+            ? "text-emerald-600 dark:text-emerald-400"
+            : "text-destructive",
+        )}
+      >
+        {formatAmount(price, 4)}
+      </span>
+      <span className="z-10">{formatAmount(amount, 2)}</span>
+      <span className="z-10 text-muted-foreground">{formatAmount(total, 2)}</span>
+    </button>
+  );
+}
+
+/**
+ * Live order book for a single asset: asks on top, bids below, with the spread
+ * in the middle and depth bars behind each level.
+ */
+export function OrderBook({
+  book,
+  isLoading,
+  error,
+  onRetry,
+  onSelectPrice,
+  assetCode = "units",
+  maxLevels = 8,
+  className,
+}: OrderBookProps) {
+  const spread = getSpread(book);
+
+  // Asks are rendered worst-price-first so the best ask sits next to the spread.
+  const asks = withCumulativeTotals(
+    (book?.asks ?? []).slice(0, maxLevels),
+  ).reverse();
+  const bids = withCumulativeTotals((book?.bids ?? []).slice(0, maxLevels));
+
+  const isEmpty = !isLoading && !error && asks.length === 0 && bids.length === 0;
+
+  return (
+    <Card className={className}>
+      <CardHeader className="border-b">
+        <CardTitle>Order book</CardTitle>
+        <CardDescription>
+          {book && !isLoading
+            ? `Spread ${formatAmount(spread.absolute, 4)} (${(spread.percentage * 100).toFixed(2)}%)`
+            : "Bids and asks for this asset"}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="px-0">
+        {isLoading && <SkeletonTable rows={6} cols={3} />}
+
+        {!isLoading && error && (
+          <div className="flex flex-col items-center gap-3 px-4 py-10 text-center">
+            <TriangleAlert className="size-5 text-destructive" aria-hidden="true" />
+            <p className="text-sm text-muted-foreground">{error}</p>
+            {onRetry && (
+              <Button variant="outline" size="sm" onClick={onRetry}>
+                <RefreshCw className="size-3.5" aria-hidden="true" />
+                Try again
+              </Button>
+            )}
+          </div>
+        )}
+
+        {isEmpty && (
+          <p className="px-4 py-10 text-center text-sm text-muted-foreground">
+            No open orders for this asset yet. Place a limit order to start the
+            book.
+          </p>
+        )}
+
+        {!isLoading && !error && !isEmpty && (
+          <div>
+            <div className="grid grid-cols-3 gap-2 px-2 pb-1 text-right text-[0.7rem] text-muted-foreground">
+              <span className="text-left">Price</span>
+              <span>Amount ({assetCode})</span>
+              <span>Total</span>
+            </div>
+
+            <div className="flex flex-col">
+              {asks.map((level) => (
+                <LevelRow
+                  key={`ask-${level.price}`}
+                  {...level}
+                  side="sell"
+                  onSelect={
+                    onSelectPrice
+                      ? () => onSelectPrice(level.price, "buy")
+                      : undefined
+                  }
+                />
+              ))}
+            </div>
+
+            <div className="my-1 flex items-center justify-between border-y bg-muted/40 px-2 py-1.5">
+              <span className="text-xs text-muted-foreground">Last price</span>
+              <span className="font-mono text-sm font-medium">
+                {formatAmount(book?.lastPrice ?? 0, 4)}
+              </span>
+            </div>
+
+            <div className="flex flex-col">
+              {bids.map((level) => (
+                <LevelRow
+                  key={`bid-${level.price}`}
+                  {...level}
+                  side="buy"
+                  onSelect={
+                    onSelectPrice
+                      ? () => onSelectPrice(level.price, "sell")
+                      : undefined
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/OrderConfirmModal.tsx
+++ b/frontend/src/components/OrderConfirmModal.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { Loader2, TriangleAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { HIGH_IMPACT_THRESHOLD, type TradeQuote } from "@/lib/trading";
+import { cn, formatAmount, formatCurrency } from "@/lib/utils";
+
+interface OrderConfirmModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  quote: TradeQuote | null;
+  assetCode: string;
+  assetName?: string;
+  isSubmitting: boolean;
+  onConfirm: () => void;
+}
+
+function SummaryRow({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: string;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1.5">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "text-right font-mono text-sm",
+          emphasis && "font-semibold",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/** Formats seconds as a short human estimate ("~10s", "~1 min"). */
+function formatEta(seconds: number): string {
+  if (seconds < 60) return `~${seconds}s`;
+  return `~${Math.round(seconds / 60)} min`;
+}
+
+/**
+ * Final review step before an order is submitted: exact amounts, fees, the
+ * slippage limit that will be enforced, and warnings for thin liquidity or
+ * heavy price impact.
+ */
+export function OrderConfirmModal({
+  open,
+  onOpenChange,
+  quote,
+  assetCode,
+  assetName,
+  isSubmitting,
+  onConfirm,
+}: OrderConfirmModalProps) {
+  if (!quote) return null;
+
+  const isBuy = quote.side === "buy";
+  const isHighImpact = quote.priceImpact >= HIGH_IMPACT_THRESHOLD;
+
+  return (
+    <Dialog open={open} onOpenChange={isSubmitting ? () => {} : onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Confirm {isBuy ? "buy" : "sell"} order
+          </DialogTitle>
+          <DialogDescription>
+            {quote.type === "market" ? "Market" : "Limit"} order for{" "}
+            {assetName ?? assetCode}. Review the numbers before signing.
+          </DialogDescription>
+        </DialogHeader>
+
+        {(isHighImpact || !quote.hasEnoughLiquidity) && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-lg bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400"
+          >
+            <TriangleAlert className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            <p>
+              {!quote.hasEnoughLiquidity
+                ? `The visible book only covers ${formatAmount(quote.fillableAmount, 2)} ${assetCode}. The remainder may stay unfilled.`
+                : `This order moves the price by ${(quote.priceImpact * 100).toFixed(2)}%. Consider a smaller size or a limit order.`}
+            </p>
+          </div>
+        )}
+
+        <div className="divide-y rounded-lg bg-muted/40 px-3 py-1">
+          <SummaryRow
+            label="Amount"
+            value={`${formatAmount(quote.amount, 4)} ${assetCode}`}
+          />
+          <SummaryRow
+            label={quote.type === "market" ? "Average price" : "Limit price"}
+            value={formatCurrency(quote.averagePrice)}
+          />
+          <SummaryRow label="Subtotal" value={formatCurrency(quote.subtotal)} />
+          <SummaryRow
+            label={`Platform fee (${(quote.platformFee / (quote.subtotal || 1) * 100).toFixed(2)}%)`}
+            value={formatCurrency(quote.platformFee)}
+          />
+          <SummaryRow
+            label="Network fee"
+            value={`${formatAmount(quote.networkFee, 5)} XLM`}
+          />
+          <SummaryRow
+            label={isBuy ? "Total to pay" : "Total to receive"}
+            value={formatCurrency(quote.total)}
+            emphasis
+          />
+        </div>
+
+        <div className="divide-y rounded-lg px-3 py-1 ring-1 ring-foreground/10">
+          <SummaryRow
+            label="Price impact"
+            value={`${(quote.priceImpact * 100).toFixed(2)}%`}
+          />
+          <SummaryRow
+            label={isBuy ? "Maximum price" : "Minimum price"}
+            value={formatCurrency(quote.worstPrice)}
+          />
+          <SummaryRow
+            label={isBuy ? "Maximum spend" : "Minimum proceeds"}
+            value={formatCurrency(quote.slippageLimit)}
+          />
+          <SummaryRow
+            label="Estimated completion"
+            value={formatEta(quote.estimatedSeconds)}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} disabled={isSubmitting} aria-busy={isSubmitting}>
+            {isSubmitting && (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            )}
+            {isSubmitting
+              ? "Submitting…"
+              : `Confirm ${isBuy ? "purchase" : "sale"}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/OrderForm.tsx
+++ b/frontend/src/components/OrderForm.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import * as React from "react";
+import { Info, Loader2, Wallet } from "lucide-react";
+
+import { OrderConfirmModal } from "@/components/OrderConfirmModal";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "@/lib/toast";
+import {
+  SLIPPAGE_PRESETS,
+  calculateQuote,
+  getBestPrice,
+  tradingApi,
+  type OrderBookSnapshot,
+  type OrderReceipt,
+  type OrderSide,
+  type OrderType,
+} from "@/lib/trading";
+import type { StellarWallet } from "@/lib/stellar";
+import { cn, formatAmount, formatCurrency } from "@/lib/utils";
+
+export interface OrderFormHandle {
+  /** Fills the form from an order book click. */
+  applyPrice: (price: number, side: OrderSide) => void;
+}
+
+interface OrderFormProps {
+  assetId: string;
+  assetCode: string;
+  assetName?: string;
+  book: OrderBookSnapshot | null;
+  /** Units of the asset the account can sell, when known. */
+  availableBalance?: number;
+  wallet?: StellarWallet;
+  onSubmitted?: (receipt: OrderReceipt) => void;
+  ref?: React.Ref<OrderFormHandle>;
+  className?: string;
+}
+
+/** Segmented control used for both the side and the order type. */
+function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  options: { value: T; label: string; activeClassName?: string }[];
+  value: T;
+  onChange: (value: T) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="grid grid-cols-2 gap-1 rounded-lg bg-muted p-1"
+    >
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          aria-pressed={value === option.value}
+          className={cn(
+            "rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+            value === option.value
+              ? (option.activeClassName ?? "bg-background text-foreground shadow-sm")
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="font-mono text-xs">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Buy/sell ticket for a single asset.
+ *
+ * Handles market and limit orders, live cost calculation (fees, slippage,
+ * price impact) and routes every submission through a confirmation step.
+ */
+export function OrderForm({
+  assetId,
+  assetCode,
+  assetName,
+  book,
+  availableBalance,
+  wallet,
+  onSubmitted,
+  ref,
+  className,
+}: OrderFormProps) {
+  const [side, setSide] = React.useState<OrderSide>("buy");
+  const [type, setType] = React.useState<OrderType>("market");
+  const [amount, setAmount] = React.useState("");
+  const [limitPrice, setLimitPrice] = React.useState("");
+  const [slippage, setSlippage] = React.useState<number>(0.005);
+  const [isConfirmOpen, setIsConfirmOpen] = React.useState(false);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      applyPrice: (price, nextSide) => {
+        setSide(nextSide);
+        setType("limit");
+        setLimitPrice(String(price));
+      },
+    }),
+    [],
+  );
+
+  const parsedAmount = Number.parseFloat(amount);
+  const parsedLimitPrice = Number.parseFloat(limitPrice);
+  const hasAmount = Number.isFinite(parsedAmount) && parsedAmount > 0;
+  const hasLimitPrice =
+    Number.isFinite(parsedLimitPrice) && parsedLimitPrice > 0;
+
+  const bestPrice = getBestPrice(book, side);
+
+  const quote = React.useMemo(
+    () =>
+      calculateQuote({
+        side,
+        type,
+        amount: hasAmount ? parsedAmount : 0,
+        limitPrice: hasLimitPrice ? parsedLimitPrice : bestPrice,
+        slippageTolerance: slippage,
+        book,
+      }),
+    [
+      side,
+      type,
+      hasAmount,
+      parsedAmount,
+      hasLimitPrice,
+      parsedLimitPrice,
+      bestPrice,
+      slippage,
+      book,
+    ],
+  );
+
+  // First blocking problem with the ticket, or null when it's ready to submit.
+  const validationError = (() => {
+    if (!amount) return null;
+    if (!hasAmount) return "Enter an amount greater than zero.";
+    if (type === "limit" && !hasLimitPrice) return "Enter a limit price.";
+    if (
+      side === "sell" &&
+      availableBalance !== undefined &&
+      parsedAmount > availableBalance
+    ) {
+      return `You only hold ${formatAmount(availableBalance, 4)} ${assetCode}.`;
+    }
+    return null;
+  })();
+
+  const canSubmit =
+    Boolean(wallet?.connected) &&
+    hasAmount &&
+    (type === "market" || hasLimitPrice) &&
+    !validationError &&
+    !isSubmitting;
+
+  const handleSubmit = async () => {
+    if (!wallet?.connected) return;
+
+    setIsSubmitting(true);
+    try {
+      const receipt = await tradingApi.submitOrder({
+        assetId,
+        side,
+        type,
+        amount: parsedAmount,
+        price: quote.averagePrice,
+        slippageTolerance: slippage,
+        account: wallet.publicKey,
+      });
+
+      setIsConfirmOpen(false);
+      setAmount("");
+      onSubmitted?.(receipt);
+
+      toast.success(
+        `${side === "buy" ? "Buy" : "Sell"} order submitted`,
+        {
+          description: `${formatAmount(parsedAmount, 4)} ${assetCode} · ${receipt.status.replace("_", " ")}`,
+        },
+      );
+    } catch (error) {
+      toast.error("Order failed", {
+        description:
+          error instanceof Error
+            ? error.message
+            : "The marketplace did not accept this order.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isBuy = side === "buy";
+
+  return (
+    <Card className={className}>
+      <CardHeader className="border-b">
+        <CardTitle>Trade {assetCode}</CardTitle>
+        <CardDescription>
+          {bestPrice > 0
+            ? `Best ${isBuy ? "ask" : "bid"} ${formatCurrency(bestPrice)}`
+            : "No live pricing available"}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        <Segmented
+          ariaLabel="Order side"
+          value={side}
+          onChange={setSide}
+          options={[
+            {
+              value: "buy",
+              label: "Buy",
+              activeClassName:
+                "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+            },
+            {
+              value: "sell",
+              label: "Sell",
+              activeClassName: "bg-destructive/15 text-destructive",
+            },
+          ]}
+        />
+
+        <Segmented
+          ariaLabel="Order type"
+          value={type}
+          onChange={setType}
+          options={[
+            { value: "market", label: "Market" },
+            { value: "limit", label: "Limit" },
+          ]}
+        />
+
+        <div className="space-y-1.5">
+          <div className="flex items-baseline justify-between">
+            <Label htmlFor="order-amount">Amount ({assetCode})</Label>
+            {availableBalance !== undefined && (
+              <button
+                type="button"
+                onClick={() => setAmount(String(availableBalance))}
+                className="text-xs font-medium text-primary hover:underline"
+              >
+                Max {formatAmount(availableBalance, 4)}
+              </button>
+            )}
+          </div>
+          <Input
+            id="order-amount"
+            inputMode="decimal"
+            placeholder="0.00"
+            value={amount}
+            onChange={(event) => setAmount(event.target.value)}
+            aria-invalid={Boolean(validationError)}
+          />
+        </div>
+
+        {type === "limit" && (
+          <div className="space-y-1.5">
+            <Label htmlFor="order-price">Limit price</Label>
+            <Input
+              id="order-price"
+              inputMode="decimal"
+              placeholder={bestPrice ? String(bestPrice) : "0.00"}
+              value={limitPrice}
+              onChange={(event) => setLimitPrice(event.target.value)}
+            />
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <Label>Slippage tolerance</Label>
+          <div className="flex flex-wrap gap-1.5">
+            {SLIPPAGE_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => setSlippage(preset)}
+                aria-pressed={slippage === preset}
+                className={cn(
+                  "rounded-md px-2.5 py-1 text-xs font-medium ring-1 transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
+                  slippage === preset
+                    ? "bg-primary text-primary-foreground ring-transparent"
+                    : "ring-foreground/10 hover:bg-muted",
+                )}
+              >
+                {(preset * 100).toFixed(preset < 0.01 ? 1 : 0)}%
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {validationError && (
+          <p role="alert" className="text-xs text-destructive">
+            {validationError}
+          </p>
+        )}
+
+        {/* Live calculator — updates on every keystroke and book update. */}
+        <div className="space-y-1.5 rounded-lg bg-muted/40 p-3">
+          <SummaryRow
+            label={type === "market" ? "Average price" : "Limit price"}
+            value={quote.averagePrice ? formatCurrency(quote.averagePrice) : "—"}
+          />
+          <SummaryRow
+            label="Platform fee"
+            value={formatCurrency(quote.platformFee)}
+          />
+          <SummaryRow
+            label="Network fee"
+            value={`${formatAmount(quote.networkFee, 5)} XLM`}
+          />
+          <SummaryRow
+            label="Price impact"
+            value={`${(quote.priceImpact * 100).toFixed(2)}%`}
+          />
+          <SummaryRow
+            label={isBuy ? "Total to pay" : "Total to receive"}
+            value={formatCurrency(quote.total)}
+          />
+        </div>
+
+        {hasAmount && !quote.hasEnoughLiquidity && (
+          <p className="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+            <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+            Only {formatAmount(quote.fillableAmount, 2)} {assetCode} is available
+            at the moment — the rest may rest on the book.
+          </p>
+        )}
+
+        {wallet?.connected ? (
+          <Button
+            className="w-full"
+            onClick={() => setIsConfirmOpen(true)}
+            disabled={!canSubmit}
+          >
+            {isSubmitting && (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            )}
+            {isBuy ? "Buy" : "Sell"} {assetCode}
+          </Button>
+        ) : (
+          <p className="flex items-center justify-center gap-2 rounded-lg bg-muted p-3 text-xs text-muted-foreground">
+            <Wallet className="size-3.5" aria-hidden="true" />
+            Connect a wallet to place orders.
+          </p>
+        )}
+      </CardContent>
+
+      <OrderConfirmModal
+        open={isConfirmOpen}
+        onOpenChange={setIsConfirmOpen}
+        quote={hasAmount ? quote : null}
+        assetCode={assetCode}
+        assetName={assetName}
+        isSubmitting={isSubmitting}
+        onConfirm={handleSubmit}
+      />
+    </Card>
+  );
+}

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -1,101 +1,196 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { Wallet } from 'lucide-react'
+
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { stellarService, StellarWallet } from '@/lib/stellar'
+import { WalletModal } from '@/components/WalletModal'
+import { StellarWallet } from '@/lib/stellar'
 import { truncateAddress } from '@/lib/utils'
-import { Wallet, LogOut } from 'lucide-react'
+import {
+  getStoredProviderId,
+  getWalletProvider,
+  restoreWalletConnection,
+  type ConnectedWallet,
+  type WalletProviderId,
+} from '@/lib/wallet-providers'
 
 interface WalletConnectProps {
   onWalletConnected: (wallet: StellarWallet) => void
   onWalletDisconnected: () => void
   wallet?: StellarWallet
+  /** `card` (default) matches the original layout; `button` is a compact trigger. */
+  variant?: 'card' | 'button'
+  /** Silently restore the previous session on mount (default: true). */
+  autoReconnect?: boolean
+  className?: string
 }
 
-export function WalletConnect({ onWalletConnected, onWalletDisconnected, wallet }: WalletConnectProps) {
-  const [isLoading, setIsLoading] = useState(false)
+/**
+ * Wallet entry point. Opens the multi-provider {@link WalletModal} instead of
+ * talking to a single wallet, and restores the previous session on mount.
+ *
+ * The props are unchanged from the original Freighter-only version, so existing
+ * pages keep working as-is.
+ */
+export function WalletConnect({
+  onWalletConnected,
+  onWalletDisconnected,
+  wallet,
+  variant = 'card',
+  autoReconnect = true,
+  className,
+}: WalletConnectProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [providerId, setProviderId] = useState<WalletProviderId | null>(null)
+  // Starts true when a restore attempt is about to run, so the button never
+  // flashes "Connect Wallet" before the previous session comes back.
+  const [isRestoring, setIsRestoring] = useState(
+    () => autoReconnect && !wallet?.connected,
+  )
 
-  const handleConnect = async () => {
-    setIsLoading(true)
-    try {
-      const connectedWallet = await stellarService.connectWallet()
-      onWalletConnected(connectedWallet)
-    } catch (error) {
-      console.error('Failed to connect wallet:', error)
-      // You could add a toast notification here
-    } finally {
-      setIsLoading(false)
+  const handleConnected = useCallback(
+    (connected: ConnectedWallet) => {
+      setProviderId(connected.providerId)
+      onWalletConnected(connected)
+    },
+    [onWalletConnected],
+  )
+
+  // One-click return: if the user connected before and the wallet is still
+  // available, reconnect without showing the modal. Also recovers which
+  // provider was used, since localStorage is unavailable during SSR.
+  useEffect(() => {
+    if (!autoReconnect || wallet?.connected) return
+
+    let cancelled = false
+
+    restoreWalletConnection()
+      .then((restored) => {
+        if (cancelled) return
+        if (restored) {
+          handleConnected(restored)
+        } else {
+          setProviderId(getStoredProviderId())
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsRestoring(false)
+      })
+
+    return () => {
+      cancelled = true
     }
-  }
+    // Runs once on mount; reconnecting on every prop change would re-prompt
+    // the user.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-  const handleDisconnect = async () => {
-    setIsLoading(true)
-    try {
-      await stellarService.disconnectWallet()
-      onWalletDisconnected()
-    } catch (error) {
-      console.error('Failed to disconnect wallet:', error)
-    } finally {
-      setIsLoading(false)
-    }
-  }
+  const handleDisconnected = useCallback(() => {
+    setProviderId(null)
+    onWalletDisconnected()
+  }, [onWalletDisconnected])
 
-  if (wallet?.connected) {
+  const activeWallet: ConnectedWallet | undefined = wallet?.connected
+    ? {
+        publicKey: wallet.publicKey,
+        connected: true,
+        providerId: providerId ?? 'freighter',
+        providerName: getWalletProvider(providerId ?? 'freighter')?.name ?? 'Wallet',
+      }
+    : undefined
+
+  const modal = (
+    <WalletModal
+      open={isModalOpen}
+      onOpenChange={setIsModalOpen}
+      onConnected={handleConnected}
+      onDisconnected={handleDisconnected}
+      wallet={activeWallet}
+    />
+  )
+
+  if (variant === 'button') {
     return (
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Wallet className="h-5 w-5" aria-hidden="true" />
-            Wallet Connected
-          </CardTitle>
-          <CardDescription>
-            Your Stellar wallet is connected and ready
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="p-3 bg-muted rounded-lg">
-            <p className="text-sm font-mono">
-              {truncateAddress(wallet.publicKey)}
-            </p>
-          </div>
-          <Button 
-            onClick={handleDisconnect} 
-            variant="outline" 
-            className="w-full"
-            disabled={isLoading}
-            aria-busy={isLoading}
-          >
-            <LogOut className="h-4 w-4 mr-2" aria-hidden="true" />
-            {isLoading ? 'Disconnecting...' : 'Disconnect'}
-          </Button>
-        </CardContent>
-      </Card>
+      <>
+        <Button
+          onClick={() => setIsModalOpen(true)}
+          variant={activeWallet ? 'outline' : 'default'}
+          className={className}
+          disabled={isRestoring && !activeWallet}
+          aria-busy={isRestoring}
+        >
+          <Wallet className="h-4 w-4" aria-hidden="true" />
+          {activeWallet
+            ? truncateAddress(activeWallet.publicKey)
+            : isRestoring
+              ? 'Reconnecting…'
+              : 'Connect Wallet'}
+        </Button>
+        {modal}
+      </>
+    )
+  }
+
+  if (activeWallet) {
+    return (
+      <>
+        <Card className={className ?? 'w-full max-w-md'}>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Wallet className="h-5 w-5" aria-hidden="true" />
+              Wallet Connected
+            </CardTitle>
+            <CardDescription>
+              Connected with {activeWallet.providerName} and ready to sign
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="p-3 bg-muted rounded-lg">
+              <p className="text-sm font-mono">
+                {truncateAddress(activeWallet.publicKey)}
+              </p>
+            </div>
+            <Button
+              onClick={() => setIsModalOpen(true)}
+              variant="outline"
+              className="w-full"
+            >
+              Manage wallet
+            </Button>
+          </CardContent>
+        </Card>
+        {modal}
+      </>
     )
   }
 
   return (
-    <Card className="w-full max-w-md">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Wallet className="h-5 w-5" aria-hidden="true" />
-          Connect Wallet
-        </CardTitle>
-        <CardDescription>
-          Connect your Freighter wallet to access the marketplace
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Button 
-          onClick={handleConnect} 
-          className="w-full"
-          disabled={isLoading}
-          aria-busy={isLoading}
-        >
-          <Wallet className="h-4 w-4 mr-2" aria-hidden="true" />
-          {isLoading ? 'Connecting...' : 'Connect Freighter Wallet'}
-        </Button>
-      </CardContent>
-    </Card>
+    <>
+      <Card className={className ?? 'w-full max-w-md'}>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Wallet className="h-5 w-5" aria-hidden="true" />
+            Connect Wallet
+          </CardTitle>
+          <CardDescription>
+            Connect a Stellar wallet — Freighter, Albedo, LOBSTR, xBull or Rabet
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            onClick={() => setIsModalOpen(true)}
+            className="w-full"
+            disabled={isRestoring}
+            aria-busy={isRestoring}
+          >
+            <Wallet className="h-4 w-4" aria-hidden="true" />
+            {isRestoring ? 'Reconnecting…' : 'Connect Wallet'}
+          </Button>
+        </CardContent>
+      </Card>
+      {modal}
+    </>
   )
 }

--- a/frontend/src/components/WalletModal.tsx
+++ b/frontend/src/components/WalletModal.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Check,
+  Copy,
+  ExternalLink,
+  Loader2,
+  LogOut,
+  RefreshCw,
+  TriangleAlert,
+  Wallet,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "@/lib/toast";
+import { cn, truncateAddress } from "@/lib/utils";
+import {
+  connectWallet,
+  disconnectWallet,
+  WALLET_PROVIDERS,
+  WalletError,
+  detectWalletProviders,
+  type ConnectedWallet,
+  type WalletProvider,
+  type WalletProviderId,
+} from "@/lib/wallet-providers";
+
+interface WalletModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Fired once a provider hands back a public key. */
+  onConnected: (wallet: ConnectedWallet) => void;
+  /** Fired after the wallet is disconnected from the connected view. */
+  onDisconnected?: () => void;
+  /** Present when a wallet is already connected — switches to the account view. */
+  wallet?: ConnectedWallet;
+}
+
+/** Square brand badge — avoids shipping remote logo images. */
+function ProviderBadge({ provider }: { provider: WalletProvider }) {
+  return (
+    <span
+      className={cn(
+        "flex size-9 shrink-0 items-center justify-center rounded-lg text-xs font-semibold",
+        provider.badgeClassName,
+      )}
+      aria-hidden="true"
+    >
+      {provider.initials}
+    </span>
+  );
+}
+
+function ProviderRow({
+  provider,
+  isAvailable,
+  isConnecting,
+  isDisabled,
+  onConnect,
+}: {
+  provider: WalletProvider;
+  isAvailable: boolean;
+  isConnecting: boolean;
+  isDisabled: boolean;
+  onConnect: () => void;
+}) {
+  // Web wallets (Albedo) work through a popup, so "not detected" means the
+  // page hasn't loaded their script rather than "install an extension".
+  const installLabel =
+    provider.kind === "web" ? "Open site" : "Install";
+
+  if (!isAvailable) {
+    return (
+      <a
+        href={provider.installUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-3 rounded-lg p-3 text-left ring-1 ring-foreground/10 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        <ProviderBadge provider={provider} />
+        <span className="flex-1 min-w-0">
+          <span className="block text-sm font-medium">{provider.name}</span>
+          <span className="block truncate text-xs text-muted-foreground">
+            Not detected — {installLabel.toLowerCase()} to continue
+          </span>
+        </span>
+        <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-muted-foreground">
+          {installLabel}
+          <ExternalLink className="size-3.5" aria-hidden="true" />
+        </span>
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onConnect}
+      disabled={isDisabled}
+      aria-busy={isConnecting}
+      className="flex items-center gap-3 rounded-lg p-3 text-left ring-1 ring-foreground/10 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-60"
+    >
+      <ProviderBadge provider={provider} />
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-medium">{provider.name}</span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {provider.description}
+        </span>
+      </span>
+      {isConnecting ? (
+        <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" aria-hidden="true" />
+      ) : (
+        <span className="flex shrink-0 items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+          <span className="size-1.5 rounded-full bg-current" aria-hidden="true" />
+          Detected
+        </span>
+      )}
+    </button>
+  );
+}
+
+/**
+ * Multi-provider wallet picker.
+ *
+ * Detects which Stellar wallets are usable in the current browser, connects
+ * through the chosen one, and doubles as the account sheet (address, copy,
+ * disconnect) once a wallet is connected.
+ */
+export function WalletModal({
+  open,
+  onOpenChange,
+  onConnected,
+  onDisconnected,
+  wallet,
+}: WalletModalProps) {
+  const [availability, setAvailability] = useState<Record<
+    WalletProviderId,
+    boolean
+  > | null>(null);
+  const [connectingId, setConnectingId] = useState<WalletProviderId | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hasCopied, setHasCopied] = useState(false);
+
+  /** Manual re-scan from the footer button. */
+  const detect = useCallback(async () => {
+    setAvailability(null);
+    setAvailability(await detectWalletProviders());
+  }, []);
+
+  // Re-probe every time the modal opens: extensions can be installed or
+  // unlocked while the tab stays open. Previous results stay on screen until
+  // the new ones land, so re-opening doesn't flash skeletons.
+  useEffect(() => {
+    if (!open || wallet) return;
+
+    let cancelled = false;
+    detectWalletProviders().then((result) => {
+      if (cancelled) return;
+      setAvailability(result);
+      setError(null);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, wallet]);
+
+  const handleConnect = async (providerId: WalletProviderId) => {
+    setConnectingId(providerId);
+    setError(null);
+
+    try {
+      const connected = await connectWallet(providerId);
+      onConnected(connected);
+      onOpenChange(false);
+      toast.success(`${connected.providerName} connected`, {
+        description: truncateAddress(connected.publicKey),
+      });
+    } catch (err) {
+      const message =
+        err instanceof WalletError
+          ? err.message
+          : "Something went wrong while connecting. Please try again.";
+      setError(message);
+      toast.error("Wallet connection failed", { description: message });
+    } finally {
+      setConnectingId(null);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    await disconnectWallet(wallet?.providerId ?? null);
+    onDisconnected?.();
+    onOpenChange(false);
+    toast.info("Wallet disconnected");
+  };
+
+  const handleCopy = async () => {
+    if (!wallet) return;
+
+    try {
+      await navigator.clipboard.writeText(wallet.publicKey);
+      setHasCopied(true);
+      window.setTimeout(() => setHasCopied(false), 2_000);
+    } catch {
+      toast.error("Could not copy the address");
+    }
+  };
+
+  const detectedCount = availability
+    ? Object.values(availability).filter(Boolean).length
+    : 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        {wallet ? (
+          // ── Connected account view ──────────────────────────────────────
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Wallet className="size-4" aria-hidden="true" />
+                {wallet.providerName} connected
+              </DialogTitle>
+              <DialogDescription>
+                Your Stellar account is linked to kor-AssetForge.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="flex items-center gap-2 rounded-lg bg-muted p-3">
+              <p className="flex-1 truncate font-mono text-sm" title={wallet.publicKey}>
+                {truncateAddress(wallet.publicKey, 10, 6)}
+              </p>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={handleCopy}
+                aria-label="Copy wallet address"
+              >
+                {hasCopied ? (
+                  <Check className="size-3.5 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+                ) : (
+                  <Copy className="size-3.5" aria-hidden="true" />
+                )}
+              </Button>
+            </div>
+
+            <Button variant="outline" className="w-full" onClick={handleDisconnect}>
+              <LogOut className="size-4" aria-hidden="true" />
+              Disconnect
+            </Button>
+          </>
+        ) : (
+          // ── Provider picker ─────────────────────────────────────────────
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Wallet className="size-4" aria-hidden="true" />
+                Connect a wallet
+              </DialogTitle>
+              <DialogDescription>
+                Choose a Stellar wallet to sign in. Your keys never leave the
+                wallet.
+              </DialogDescription>
+            </DialogHeader>
+
+            {error && (
+              <div
+                role="alert"
+                className="flex items-start gap-2 rounded-lg bg-destructive/10 p-3 text-sm text-destructive"
+              >
+                <TriangleAlert className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                <p className="flex-1">{error}</p>
+              </div>
+            )}
+
+            <div className="flex flex-col gap-2">
+              {availability === null
+                ? // Loading: one skeleton row per provider.
+                  WALLET_PROVIDERS.map((provider) => (
+                    <div
+                      key={provider.id}
+                      className="flex items-center gap-3 rounded-lg p-3 ring-1 ring-foreground/10"
+                    >
+                      <Skeleton className="size-9 rounded-lg" />
+                      <div className="flex-1 space-y-2">
+                        <Skeleton className="h-3 w-24" />
+                        <Skeleton className="h-3 w-40" />
+                      </div>
+                    </div>
+                  ))
+                : WALLET_PROVIDERS.map((provider) => (
+                    <ProviderRow
+                      key={provider.id}
+                      provider={provider}
+                      isAvailable={availability[provider.id]}
+                      isConnecting={connectingId === provider.id}
+                      isDisabled={connectingId !== null}
+                      onConnect={() => handleConnect(provider.id)}
+                    />
+                  ))}
+            </div>
+
+            <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+              <span>
+                {availability === null
+                  ? "Detecting wallets…"
+                  : `${detectedCount} of ${WALLET_PROVIDERS.length} wallets detected`}
+              </span>
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={detect}
+                disabled={availability === null || connectingId !== null}
+              >
+                <RefreshCw className="size-3" aria-hidden="true" />
+                Re-scan
+              </Button>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/bundles/BundleForm.tsx
+++ b/frontend/src/components/bundles/BundleForm.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Package, Plus, X } from "lucide-react";
 
 interface BundleFormProps {

--- a/frontend/src/components/bundles/BundleList.tsx
+++ b/frontend/src/components/bundles/BundleList.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Package, Tag, ShoppingCart } from "lucide-react";
 
 export interface BundleRecord {

--- a/frontend/src/components/escrow/DisputePanel.tsx
+++ b/frontend/src/components/escrow/DisputePanel.tsx
@@ -7,7 +7,7 @@ import { EscrowRecord } from "./EscrowList";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Gavel } from "lucide-react";
 
 interface DisputePanelProps {

--- a/frontend/src/components/escrow/EscrowForm.tsx
+++ b/frontend/src/components/escrow/EscrowForm.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Lock } from "lucide-react";
 
 interface EscrowFormProps {

--- a/frontend/src/components/escrow/EscrowList.tsx
+++ b/frontend/src/components/escrow/EscrowList.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { CheckCircle, AlertTriangle, Clock } from "lucide-react";
 
 export interface EscrowRecord {

--- a/frontend/src/components/governance/DelegatePanel.tsx
+++ b/frontend/src/components/governance/DelegatePanel.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { Users, UserMinus } from "lucide-react";
 
 interface DelegatePanelProps {

--- a/frontend/src/components/governance/ProposalForm.tsx
+++ b/frontend/src/components/governance/ProposalForm.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { FilePlus } from "lucide-react";
 
 interface ProposalFormProps {

--- a/frontend/src/components/governance/VotePanel.tsx
+++ b/frontend/src/components/governance/VotePanel.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { ThumbsUp, ThumbsDown, CheckCircle, XCircle, Clock } from "lucide-react";
 
 interface VotePanelProps {

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import {
+  CheckCircle2,
+  Info,
+  Loader2,
+  TriangleAlert,
+  X,
+  XCircle,
+} from "lucide-react";
+
+import {
+  dismissToast,
+  getServerToasts,
+  getToasts,
+  subscribeToToasts,
+  type ToastRecord,
+  type ToastVariant,
+} from "@/lib/toast";
+import { cn } from "@/lib/utils";
+
+export type ToastPosition =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right";
+
+interface ToastContainerProps {
+  /** Where the stack is anchored (default: bottom-right). */
+  position?: ToastPosition;
+  /** How many toasts render at once — the rest stay queued (default: 3). */
+  maxVisible?: number;
+}
+
+const POSITION_CLASSES: Record<ToastPosition, string> = {
+  "top-left": "top-0 left-0 items-start",
+  "top-center": "top-0 left-1/2 -translate-x-1/2 items-center",
+  "top-right": "top-0 right-0 items-end",
+  "bottom-left": "bottom-0 left-0 items-start",
+  "bottom-center": "bottom-0 left-1/2 -translate-x-1/2 items-center",
+  "bottom-right": "bottom-0 right-0 items-end",
+};
+
+const VARIANT_ICON: Record<ToastVariant, React.ElementType> = {
+  default: Info,
+  success: CheckCircle2,
+  error: XCircle,
+  warning: TriangleAlert,
+  info: Info,
+  loading: Loader2,
+};
+
+/** Accent colours per variant. Neutral variants inherit the popover palette. */
+const VARIANT_ICON_CLASSES: Record<ToastVariant, string> = {
+  default: "text-muted-foreground",
+  success: "text-emerald-600 dark:text-emerald-400",
+  error: "text-destructive",
+  warning: "text-amber-600 dark:text-amber-400",
+  info: "text-sky-600 dark:text-sky-400",
+  loading: "text-muted-foreground animate-spin",
+};
+
+const VARIANT_RING_CLASSES: Record<ToastVariant, string> = {
+  default: "ring-foreground/10",
+  success: "ring-emerald-500/30",
+  error: "ring-destructive/30",
+  warning: "ring-amber-500/30",
+  info: "ring-sky-500/30",
+  loading: "ring-foreground/10",
+};
+
+/** Exit animation length — kept in sync with the leaving classes below. */
+const EXIT_DURATION = 160;
+
+// Hydration-safe "are we on the client?" check: the server snapshot is false,
+// the client snapshot is true, and the value never changes afterwards.
+const neverChanges = () => () => {};
+const onClient = () => true;
+const onServer = () => false;
+
+function ToastItem({
+  toast,
+  position,
+}: {
+  toast: ToastRecord;
+  position: ToastPosition;
+}) {
+  const [isLeaving, setIsLeaving] = React.useState(false);
+  const [isPaused, setIsPaused] = React.useState(false);
+
+  const Icon = VARIANT_ICON[toast.variant];
+  const isTop = position.startsWith("top");
+
+  const close = React.useCallback(() => {
+    setIsLeaving(true);
+    window.setTimeout(() => dismissToast(toast.id), EXIT_DURATION);
+  }, [toast.id]);
+
+  // Auto-dismiss. Re-armed whenever the toast is updated (e.g. loading →
+  // success) and suspended while the pointer or keyboard focus is on the stack.
+  React.useEffect(() => {
+    if (isPaused || isLeaving) return;
+    if (!Number.isFinite(toast.duration)) return;
+
+    const timer = window.setTimeout(close, toast.duration);
+    return () => window.clearTimeout(timer);
+  }, [close, isPaused, isLeaving, toast.duration, toast.updatedAt]);
+
+  const handleAction = () => {
+    // An action handler may return `false` to keep the toast on screen.
+    const keepOpen = toast.action?.onClick() === false;
+    if (!keepOpen) close();
+  };
+
+  return (
+    <div
+      // Errors interrupt the screen reader; everything else is announced politely.
+      role={toast.variant === "error" ? "alert" : "status"}
+      aria-atomic="true"
+      data-variant={toast.variant}
+      data-state={isLeaving ? "closed" : "open"}
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+      onFocusCapture={() => setIsPaused(true)}
+      onBlurCapture={() => setIsPaused(false)}
+      className={cn(
+        "pointer-events-auto flex w-full items-start gap-3 rounded-xl bg-popover p-3.5 text-sm text-popover-foreground shadow-lg ring-1",
+        VARIANT_RING_CLASSES[toast.variant],
+        "motion-safe:transition-all motion-safe:duration-150 motion-safe:ease-out",
+        isLeaving
+          ? "motion-safe:scale-95 motion-safe:opacity-0"
+          : "motion-safe:animate-in motion-safe:fade-in-0",
+        !isLeaving &&
+          (isTop
+            ? "motion-safe:slide-in-from-top-2"
+            : "motion-safe:slide-in-from-bottom-2"),
+      )}
+    >
+      <Icon
+        className={cn("mt-0.5 size-4 shrink-0", VARIANT_ICON_CLASSES[toast.variant])}
+        aria-hidden="true"
+      />
+
+      <div className="flex-1 space-y-1">
+        <p className="font-medium leading-snug break-words">{toast.title}</p>
+        {toast.description && (
+          <p className="text-xs leading-relaxed text-muted-foreground break-words">
+            {toast.description}
+          </p>
+        )}
+        {toast.action && (
+          <button
+            type="button"
+            onClick={handleAction}
+            className="mt-1 rounded-md text-xs font-medium text-primary underline-offset-4 transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          >
+            {toast.action.label}
+          </button>
+        )}
+      </div>
+
+      {toast.dismissible && (
+        <button
+          type="button"
+          onClick={close}
+          aria-label="Dismiss notification"
+          className="-mr-1 -mt-1 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        >
+          <X className="size-3.5" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Renders the toast queue in a portal. Mount once, near the end of the root
+ * layout — everything else talks to it through `toast()` from `@/lib/toast`.
+ */
+export function ToastContainer({
+  position = "bottom-right",
+  maxVisible = 3,
+}: ToastContainerProps) {
+  const toasts = React.useSyncExternalStore(
+    subscribeToToasts,
+    getToasts,
+    getServerToasts,
+  );
+
+  // Portals need a DOM target, so wait for hydration before rendering.
+  const isMounted = React.useSyncExternalStore(
+    neverChanges,
+    onClient,
+    onServer,
+  );
+
+  if (!isMounted) return null;
+
+  const visible = toasts.slice(0, maxVisible);
+  const queued = toasts.length - visible.length;
+  const isTop = position.startsWith("top");
+
+  return createPortal(
+    <div
+      // The wrapper is click-through; individual toasts opt back in.
+      // Announcements come from each toast's role (status/alert), so the
+      // wrapper deliberately has no aria-live of its own — that would make
+      // screen readers read every toast twice.
+      className={cn(
+        "pointer-events-none fixed z-[100] flex w-full max-w-full gap-2 p-4 sm:max-w-sm",
+        // Column direction keeps the newest toast closest to the screen edge
+        // and the overflow counter furthest from it.
+        isTop ? "flex-col-reverse" : "flex-col",
+        POSITION_CLASSES[position],
+      )}
+    >
+      {queued > 0 && (
+        <p className="px-1 text-xs text-muted-foreground">
+          +{queued} more notification{queued > 1 ? "s" : ""}
+        </p>
+      )}
+
+      {visible.map((toastRecord) => (
+        <ToastItem
+          key={toastRecord.id}
+          toast={toastRecord}
+          position={position}
+        />
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 backdrop-blur-[2px] data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-5 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-150 sm:w-full",
+          "max-h-[calc(100dvh-2rem)] overflow-y-auto",
+          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close-button"
+            aria-label="Close"
+            className="absolute top-4 right-4 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          >
+            <XIcon className="size-4" aria-hidden="true" />
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-1.5 pr-8", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("font-heading text-base leading-snug font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/components/verification/VerificationRequestForm.tsx
+++ b/frontend/src/components/verification/VerificationRequestForm.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { ShieldCheck } from "lucide-react";
 
 interface VerificationRequestFormProps {

--- a/frontend/src/components/verification/VerifierDashboard.tsx
+++ b/frontend/src/components/verification/VerifierDashboard.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { ShieldCheck, ShieldOff, ExternalLink } from "lucide-react";
 
 export interface VerificationRequest {

--- a/frontend/src/hooks/useActivityFeed.ts
+++ b/frontend/src/hooks/useActivityFeed.ts
@@ -1,0 +1,358 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  WebSocketClient,
+  getWebSocketUrl,
+  type WSStatus,
+} from "@/lib/websocket";
+
+export type ActivityType =
+  | "trade"
+  | "listing"
+  | "proposal"
+  | "vote"
+  | "mint"
+  | "fractionalize"
+  | "escrow"
+  | "verification";
+
+export interface ActivityEvent {
+  id: string;
+  type: ActivityType;
+  title: string;
+  description?: string;
+  /** Wallet address that triggered the event. */
+  actor?: string;
+  assetId?: string;
+  assetName?: string;
+  amount?: number;
+  /** Epoch milliseconds. */
+  timestamp: number;
+  txHash?: string;
+}
+
+export interface ActivityGroup {
+  /** "Today", "Yesterday", or a formatted date. */
+  label: string;
+  events: ActivityEvent[];
+}
+
+interface ActivityPage {
+  events: ActivityEvent[];
+  nextCursor?: string;
+  hasMore: boolean;
+}
+
+export interface UseActivityFeedOptions {
+  /** Restrict the feed to these event types. Empty means "everything". */
+  types?: ActivityType[];
+  /** Restrict the feed to a single asset. */
+  assetId?: string;
+  /** Events fetched per page (default: 20). */
+  pageSize?: number;
+  /** Subscribe to live updates over WebSocket (default: true). */
+  live?: boolean;
+  /** Upper bound on retained events, so long sessions don't grow forever. */
+  maxEvents?: number;
+}
+
+export interface UseActivityFeedResult {
+  events: ActivityEvent[];
+  /** `events` bucketed by day, ready to render as sections. */
+  groups: ActivityGroup[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  /** True while the feed is showing locally generated sample events. */
+  isSample: boolean;
+  liveStatus: WSStatus;
+  loadMore: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Groups events into Today / Yesterday / explicit dates, newest first. */
+export function groupActivitiesByDay(events: ActivityEvent[]): ActivityGroup[] {
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const todayMs = startOfToday.getTime();
+
+  const groups = new Map<string, ActivityEvent[]>();
+
+  for (const event of events) {
+    let label: string;
+
+    if (event.timestamp >= todayMs) {
+      label = "Today";
+    } else if (event.timestamp >= todayMs - DAY_MS) {
+      label = "Yesterday";
+    } else {
+      label = new Intl.DateTimeFormat("en-US", {
+        month: "long",
+        day: "numeric",
+        year:
+          new Date(event.timestamp).getFullYear() === startOfToday.getFullYear()
+            ? undefined
+            : "numeric",
+      }).format(new Date(event.timestamp));
+    }
+
+    const bucket = groups.get(label);
+    if (bucket) {
+      bucket.push(event);
+    } else {
+      groups.set(label, [event]);
+    }
+  }
+
+  return Array.from(groups, ([label, groupEvents]) => ({
+    label,
+    events: groupEvents,
+  }));
+}
+
+// ── Sample data ──────────────────────────────────────────────────────────────
+
+const SAMPLE_TEMPLATES: {
+  type: ActivityType;
+  title: string;
+  description: string;
+}[] = [
+  {
+    type: "trade",
+    title: "Downtown Office Tower traded",
+    description: "120 DOT filled at $104.20",
+  },
+  {
+    type: "listing",
+    title: "Harbor Warehouse Fund listed",
+    description: "500 HWF offered at $58.00",
+  },
+  {
+    type: "proposal",
+    title: "Proposal #18 opened",
+    description: "Increase quarterly dividend payout",
+  },
+  {
+    type: "vote",
+    title: "Vote cast on proposal #17",
+    description: "1,240 votes in favour",
+  },
+  {
+    type: "mint",
+    title: "Retail Plaza Token minted",
+    description: "10,000 RPT issued",
+  },
+  {
+    type: "fractionalize",
+    title: "Luxury Residences fractionalised",
+    description: "Split into 5,000 shares",
+  },
+  {
+    type: "escrow",
+    title: "Escrow released",
+    description: "Funds delivered to the seller",
+  },
+  {
+    type: "verification",
+    title: "Industrial Park Token verified",
+    description: "Documents approved by a verifier",
+  },
+];
+
+/**
+ * Deterministic sample events used when the activity API isn't reachable, so
+ * the feed stays explorable in local development.
+ */
+function generateSampleActivity(
+  count: number,
+  before: number = Date.now(),
+): ActivityEvent[] {
+  return Array.from({ length: count }, (_, index) => {
+    const template = SAMPLE_TEMPLATES[index % SAMPLE_TEMPLATES.length];
+    // Spread events out: a few minutes apart at first, then hours.
+    const offset = (index + 1) * (index < 5 ? 7 * 60_000 : 5 * 60 * 60_000);
+
+    return {
+      id: `sample-${before}-${index}`,
+      type: template.type,
+      title: template.title,
+      description: template.description,
+      actor: `GA${(index * 7919).toString(36).toUpperCase().padStart(6, "X")}…`,
+      timestamp: before - offset,
+    } satisfies ActivityEvent;
+  });
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Loads the platform activity feed with cursor pagination, live WebSocket
+ * updates and day grouping.
+ *
+ * ```tsx
+ * const { groups, hasMore, loadMore } = useActivityFeed({ types: ["trade"] })
+ * ```
+ */
+export function useActivityFeed({
+  types,
+  assetId,
+  pageSize = 20,
+  live = true,
+  maxEvents = 200,
+}: UseActivityFeedOptions = {}): UseActivityFeedResult {
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [isSample, setIsSample] = useState(false);
+  const [liveStatus, setLiveStatus] = useState<WSStatus>("disconnected");
+
+  const cursorRef = useRef<string | undefined>(undefined);
+
+  // Serialised so the fetch callbacks don't change identity on every render.
+  const typesKey = types?.join(",") ?? "";
+
+  const fetchPage = useCallback(
+    async (cursor?: string): Promise<ActivityPage> => {
+      const query = new URLSearchParams({ limit: String(pageSize) });
+      if (cursor) query.set("cursor", cursor);
+      if (typesKey) query.set("types", typesKey);
+      if (assetId) query.set("asset_id", assetId);
+
+      const res = await fetch(`${API_URL}/api/v1/activity?${query}`);
+      if (!res.ok) throw new Error(`Activity feed unavailable (${res.status})`);
+
+      const data = (await res.json()) as Partial<ActivityPage>;
+      return {
+        events: data.events ?? [],
+        nextCursor: data.nextCursor,
+        hasMore: data.hasMore ?? Boolean(data.nextCursor),
+      };
+    },
+    [pageSize, typesKey, assetId],
+  );
+
+  const refresh = useCallback(async () => {
+    try {
+      const page = await fetchPage();
+      cursorRef.current = page.nextCursor;
+      setEvents(page.events);
+      setHasMore(page.hasMore);
+      setIsSample(false);
+      setError(null);
+    } catch {
+      // Fall back to sample events rather than an empty screen, and say so.
+      cursorRef.current = undefined;
+      setEvents(generateSampleActivity(pageSize));
+      setHasMore(true);
+      setIsSample(true);
+      setError(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchPage, pageSize]);
+
+  const loadMore = useCallback(async () => {
+    if (isLoadingMore || !hasMore) return;
+
+    setIsLoadingMore(true);
+    try {
+      if (isSample) {
+        // Keep paginating the sample timeline backwards in time.
+        const oldest = events[events.length - 1]?.timestamp ?? Date.now();
+        const combined = [
+          ...events,
+          ...generateSampleActivity(pageSize, oldest),
+        ].slice(0, maxEvents);
+
+        setEvents(combined);
+        setHasMore(combined.length < maxEvents);
+        return;
+      }
+
+      const page = await fetchPage(cursorRef.current);
+      cursorRef.current = page.nextCursor;
+      setEvents((current) => {
+        const seen = new Set(current.map((event) => event.id));
+        const merged = [
+          ...current,
+          ...page.events.filter((event) => !seen.has(event.id)),
+        ];
+        return merged.slice(0, maxEvents);
+      });
+      setHasMore(page.hasMore);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Could not load more activity.",
+      );
+      setHasMore(false);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [events, fetchPage, hasMore, isLoadingMore, isSample, maxEvents, pageSize]);
+
+  // Initial load, and a reload whenever the filters change. Queued as a task so
+  // the effect body performs no synchronous state updates.
+  useEffect(() => {
+    const timer = window.setTimeout(refresh, 0);
+    return () => window.clearTimeout(timer);
+  }, [refresh]);
+
+  // Live updates: new events are prepended, de-duplicated and filtered with the
+  // same rules as the REST query.
+  useEffect(() => {
+    if (!live) return;
+
+    const activeTypes = typesKey ? typesKey.split(",") : [];
+    const client = new WebSocketClient({
+      url: getWebSocketUrl(),
+      onStatusChange: setLiveStatus,
+    });
+
+    const unsubscribe = client.subscribe<ActivityEvent>(
+      "activity",
+      ({ payload }) => {
+        if (!payload?.id) return;
+        if (activeTypes.length > 0 && !activeTypes.includes(payload.type)) return;
+        if (assetId && payload.assetId !== assetId) return;
+
+        setEvents((current) =>
+          current.some((event) => event.id === payload.id)
+            ? current
+            : [payload, ...current].slice(0, maxEvents),
+        );
+      },
+    );
+
+    client.connect();
+    client.send("subscribe", { channel: "activity", types: activeTypes, assetId });
+
+    return () => {
+      unsubscribe();
+      client.disconnect();
+    };
+  }, [live, typesKey, assetId, maxEvents]);
+
+  const groups = useMemo(() => groupActivitiesByDay(events), [events]);
+
+  return {
+    events,
+    groups,
+    isLoading,
+    isLoadingMore,
+    error,
+    hasMore,
+    isSample,
+    liveStatus,
+    loadMore,
+    refresh,
+  };
+}

--- a/frontend/src/lib/toast.ts
+++ b/frontend/src/lib/toast.ts
@@ -1,0 +1,237 @@
+/**
+ * Headless toast store.
+ *
+ * The store lives outside React so any module (API clients, event handlers,
+ * non-component code) can raise a toast with a plain function call:
+ *
+ * ```ts
+ * import { toast } from "@/lib/toast"
+ *
+ * toast.success("Proposal created")
+ * toast.error("Vote failed", { description: err.message })
+ * toast.info("New block", { action: { label: "View", onClick: openBlock } })
+ * ```
+ *
+ * Rendering lives in `@/components/ui/Toast` — the container subscribes to this
+ * store and owns the auto-dismiss timers (so they can pause on hover).
+ */
+
+export type ToastVariant =
+  | "default"
+  | "success"
+  | "error"
+  | "warning"
+  | "info"
+  | "loading";
+
+export interface ToastAction {
+  label: string;
+  /** Invoked on click. The toast is dismissed afterwards unless this returns false. */
+  onClick: () => void | boolean;
+}
+
+export interface ToastOptions {
+  /** Supply to update an existing toast instead of pushing a new one. */
+  id?: string;
+  /** Secondary line rendered under the title. */
+  description?: string;
+  variant?: ToastVariant;
+  /** Auto-dismiss delay in ms. `0` or `Infinity` keeps the toast until dismissed. */
+  duration?: number;
+  action?: ToastAction;
+  /** Show the close button (default: true). */
+  dismissible?: boolean;
+  /** Called when the toast leaves the queue, for any reason. */
+  onDismiss?: (id: string) => void;
+}
+
+export interface ToastRecord extends Omit<ToastOptions, "id" | "duration"> {
+  id: string;
+  title: string;
+  variant: ToastVariant;
+  duration: number;
+  dismissible: boolean;
+  /** Bumped on every update so the renderer knows to re-arm its timer. */
+  updatedAt: number;
+}
+
+/** Per-variant defaults — errors linger, loading never auto-dismisses. */
+const DEFAULT_DURATION: Record<ToastVariant, number> = {
+  default: 4_000,
+  success: 4_000,
+  info: 5_000,
+  warning: 6_000,
+  error: 8_000,
+  loading: Infinity,
+};
+
+/** Frozen empty snapshot so server renders stay referentially stable. */
+const EMPTY: readonly ToastRecord[] = Object.freeze([]);
+
+let toasts: readonly ToastRecord[] = EMPTY;
+let counter = 0;
+
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+/** Subscribe to queue changes. Returns an unsubscribe function. */
+export function subscribeToToasts(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Current queue — a new array reference on every change (useSyncExternalStore safe). */
+export function getToasts(): readonly ToastRecord[] {
+  return toasts;
+}
+
+/** Server snapshot: toasts are client-only, so the queue is always empty on the server. */
+export function getServerToasts(): readonly ToastRecord[] {
+  return EMPTY;
+}
+
+function normalizeDuration(
+  duration: number | undefined,
+  variant: ToastVariant,
+): number {
+  if (duration === undefined) return DEFAULT_DURATION[variant];
+  // `0` is the ergonomic way to ask for a sticky toast.
+  return duration <= 0 ? Infinity : duration;
+}
+
+/**
+ * Push a toast (or update one when `options.id` matches a queued toast).
+ * Returns the toast id so callers can update or dismiss it later.
+ */
+function push(
+  title: string,
+  variant: ToastVariant,
+  options: ToastOptions = {},
+): string {
+  const id = options.id ?? `toast-${++counter}`;
+  const existing = toasts.find((t) => t.id === id);
+
+  const record: ToastRecord = {
+    id,
+    title,
+    description: options.description,
+    variant,
+    duration: normalizeDuration(options.duration, variant),
+    dismissible: options.dismissible ?? true,
+    action: options.action,
+    onDismiss: options.onDismiss ?? existing?.onDismiss,
+    updatedAt: Date.now(),
+  };
+
+  toasts = existing
+    ? toasts.map((t) => (t.id === id ? record : t))
+    : [...toasts, record];
+
+  notify();
+  return id;
+}
+
+/** Remove a single toast. No-op when the id is unknown. */
+export function dismissToast(id: string): void {
+  const target = toasts.find((t) => t.id === id);
+  if (!target) return;
+
+  toasts = toasts.filter((t) => t.id !== id);
+  notify();
+  target.onDismiss?.(id);
+}
+
+/** Remove every queued toast. */
+export function dismissAllToasts(): void {
+  const dismissed = toasts;
+  toasts = EMPTY;
+  notify();
+  for (const t of dismissed) t.onDismiss?.(t.id);
+}
+
+type ToastFn = (title: string, options?: ToastOptions) => string;
+
+interface ToastApi extends ToastFn {
+  success: ToastFn;
+  error: ToastFn;
+  warning: ToastFn;
+  info: ToastFn;
+  loading: ToastFn;
+  dismiss: (id: string) => void;
+  dismissAll: () => void;
+  /**
+   * Bind a toast to a promise: shows a loading toast, then swaps it for the
+   * success or error message when the promise settles.
+   *
+   * ```ts
+   * await toast.promise(submitOrder(), {
+   *   loading: "Submitting order…",
+   *   success: "Order submitted",
+   *   error: (err) => err.message,
+   * })
+   * ```
+   */
+  promise: <T>(
+    promise: Promise<T>,
+    messages: {
+      loading: string;
+      success: string | ((value: T) => string);
+      error: string | ((error: unknown) => string);
+    },
+    options?: ToastOptions,
+  ) => Promise<T>;
+}
+
+const toastFn: ToastFn = (title, options) =>
+  push(title, options?.variant ?? "default", options);
+
+export const toast: ToastApi = Object.assign(toastFn, {
+  success: (title: string, options?: ToastOptions) =>
+    push(title, "success", options),
+  error: (title: string, options?: ToastOptions) =>
+    push(title, "error", options),
+  warning: (title: string, options?: ToastOptions) =>
+    push(title, "warning", options),
+  info: (title: string, options?: ToastOptions) => push(title, "info", options),
+  loading: (title: string, options?: ToastOptions) =>
+    push(title, "loading", options),
+  dismiss: dismissToast,
+  dismissAll: dismissAllToasts,
+  promise: async <T,>(
+    promise: Promise<T>,
+    messages: {
+      loading: string;
+      success: string | ((value: T) => string);
+      error: string | ((error: unknown) => string);
+    },
+    options?: ToastOptions,
+  ): Promise<T> => {
+    const id = push(messages.loading, "loading", { ...options, duration: 0 });
+
+    try {
+      const value = await promise;
+      push(
+        typeof messages.success === "function"
+          ? messages.success(value)
+          : messages.success,
+        "success",
+        { ...options, id, duration: options?.duration },
+      );
+      return value;
+    } catch (error) {
+      push(
+        typeof messages.error === "function"
+          ? messages.error(error)
+          : messages.error,
+        "error",
+        { ...options, id, duration: options?.duration },
+      );
+      throw error;
+    }
+  },
+});

--- a/frontend/src/lib/trading.ts
+++ b/frontend/src/lib/trading.ts
@@ -1,0 +1,381 @@
+/**
+ * Trading domain: order book access, quote maths and order submission.
+ *
+ * All pricing logic lives here (rather than in the components) so the order
+ * form, the confirmation modal and any future automation agree on the numbers.
+ */
+
+import {
+  WebSocketClient,
+  getWebSocketUrl,
+  type WSStatus,
+} from "@/lib/websocket";
+
+export type OrderSide = "buy" | "sell";
+export type OrderType = "market" | "limit";
+
+export interface OrderBookEntry {
+  price: number;
+  amount: number;
+}
+
+export interface OrderBookSnapshot {
+  /** Buy-side interest, best (highest) price first. */
+  bids: OrderBookEntry[];
+  /** Sell-side interest, best (lowest) price first. */
+  asks: OrderBookEntry[];
+  lastPrice: number;
+  updatedAt: number;
+  /** True when the data is locally generated because the API isn't available. */
+  isSample?: boolean;
+}
+
+export interface RecentTrade {
+  id: string;
+  side: OrderSide;
+  price: number;
+  amount: number;
+  timestamp: number;
+}
+
+export interface QuoteInput {
+  side: OrderSide;
+  type: OrderType;
+  /** Units of the asset being bought or sold. */
+  amount: number;
+  /** Required for limit orders; ignored for market orders. */
+  limitPrice?: number;
+  /** Fraction, e.g. 0.005 for 0.5%. */
+  slippageTolerance: number;
+  book: OrderBookSnapshot | null;
+}
+
+export interface TradeQuote {
+  side: OrderSide;
+  type: OrderType;
+  amount: number;
+  /** Volume-weighted fill price for market orders, limit price otherwise. */
+  averagePrice: number;
+  /** amount × averagePrice, before fees. */
+  subtotal: number;
+  platformFee: number;
+  /** Stellar base fee, denominated in XLM and quoted separately from `total`. */
+  networkFee: number;
+  /** What the wallet pays (buy) or receives (sell), platform fee included. */
+  total: number;
+  /** Difference between the best price and the average fill, as a fraction. */
+  priceImpact: number;
+  /** Worst price still accepted once slippage tolerance is applied. */
+  worstPrice: number;
+  /** Buy: maximum spend. Sell: minimum proceeds. Both after fees. */
+  slippageLimit: number;
+  /** How much of `amount` the visible book can fill. */
+  fillableAmount: number;
+  hasEnoughLiquidity: boolean;
+  estimatedSeconds: number;
+}
+
+export interface OrderRequest {
+  assetId: string;
+  side: OrderSide;
+  type: OrderType;
+  amount: number;
+  price: number;
+  slippageTolerance: number;
+  account: string;
+}
+
+export interface OrderReceipt {
+  id: string;
+  status: "pending" | "filled" | "partially_filled" | "rejected";
+  txHash?: string;
+  filledAmount?: number;
+  submittedAt: number;
+}
+
+/** Platform trading fee (0.30%). */
+export const PLATFORM_FEE_RATE = 0.003;
+
+/** Stellar base fee per operation, in XLM. */
+export const NETWORK_FEE = 0.00001;
+
+/** Selectable slippage tolerances, as fractions. */
+export const SLIPPAGE_PRESETS = [0.001, 0.005, 0.01, 0.03] as const;
+
+/** Above this price impact the confirmation modal warns before submitting. */
+export const HIGH_IMPACT_THRESHOLD = 0.02;
+
+/** Average Stellar ledger close time, used for completion estimates. */
+const LEDGER_SECONDS = 5;
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+// ── Quote maths ──────────────────────────────────────────────────────────────
+
+/** Best available price for a side: lowest ask when buying, highest bid when selling. */
+export function getBestPrice(
+  book: OrderBookSnapshot | null,
+  side: OrderSide,
+): number {
+  if (!book) return 0;
+  const levels = side === "buy" ? book.asks : book.bids;
+  return levels[0]?.price ?? book.lastPrice;
+}
+
+/** Spread between best bid and best ask, absolute and as a fraction of the mid. */
+export function getSpread(book: OrderBookSnapshot | null): {
+  absolute: number;
+  percentage: number;
+} {
+  const bestBid = book?.bids[0]?.price ?? 0;
+  const bestAsk = book?.asks[0]?.price ?? 0;
+  if (!bestBid || !bestAsk) return { absolute: 0, percentage: 0 };
+
+  const absolute = bestAsk - bestBid;
+  const mid = (bestAsk + bestBid) / 2;
+  return { absolute, percentage: mid > 0 ? absolute / mid : 0 };
+}
+
+/**
+ * Walks the book to work out what a market order would actually fill at.
+ * Returns the volume-weighted average price and how much of the request the
+ * visible depth can cover.
+ */
+function walkBook(
+  levels: OrderBookEntry[],
+  amount: number,
+): { averagePrice: number; fillableAmount: number } {
+  let remaining = amount;
+  let cost = 0;
+  let filled = 0;
+
+  for (const level of levels) {
+    if (remaining <= 0) break;
+    const take = Math.min(remaining, level.amount);
+    cost += take * level.price;
+    filled += take;
+    remaining -= take;
+  }
+
+  return {
+    averagePrice: filled > 0 ? cost / filled : 0,
+    fillableAmount: filled,
+  };
+}
+
+/** Builds the full cost breakdown shown in the form and the confirmation modal. */
+export function calculateQuote({
+  side,
+  type,
+  amount,
+  limitPrice,
+  slippageTolerance,
+  book,
+}: QuoteInput): TradeQuote {
+  const levels = side === "buy" ? (book?.asks ?? []) : (book?.bids ?? []);
+  const bestPrice = getBestPrice(book, side);
+
+  const marketFill = walkBook(levels, amount);
+  const isLimit = type === "limit";
+
+  const averagePrice = isLimit
+    ? (limitPrice ?? 0)
+    : marketFill.averagePrice || bestPrice;
+
+  const fillableAmount = isLimit ? amount : marketFill.fillableAmount;
+  const subtotal = amount * averagePrice;
+  const platformFee = subtotal * PLATFORM_FEE_RATE;
+
+  // Buyers pay the fee on top; sellers have it deducted from the proceeds.
+  // The network fee is XLM-denominated, so it is reported separately rather
+  // than mixed into the quote-currency total.
+  const total =
+    side === "buy" ? subtotal + platformFee : subtotal - platformFee;
+
+  const priceImpact =
+    bestPrice > 0 && averagePrice > 0
+      ? Math.abs(averagePrice - bestPrice) / bestPrice
+      : 0;
+
+  const worstPrice =
+    side === "buy"
+      ? averagePrice * (1 + slippageTolerance)
+      : averagePrice * (1 - slippageTolerance);
+
+  const slippageSubtotal = amount * worstPrice;
+  const slippageLimit =
+    side === "buy"
+      ? slippageSubtotal + slippageSubtotal * PLATFORM_FEE_RATE
+      : slippageSubtotal - slippageSubtotal * PLATFORM_FEE_RATE;
+
+  // Market orders clear in a ledger or two; limit orders wait for a match.
+  const estimatedSeconds = isLimit ? LEDGER_SECONDS * 12 : LEDGER_SECONDS * 2;
+
+  return {
+    side,
+    type,
+    amount,
+    averagePrice,
+    subtotal,
+    platformFee,
+    networkFee: NETWORK_FEE,
+    total,
+    priceImpact,
+    worstPrice,
+    slippageLimit,
+    fillableAmount,
+    hasEnoughLiquidity: isLimit || fillableAmount >= amount,
+    estimatedSeconds,
+  };
+}
+
+/** Cumulative depth per level, used for the order book's background bars. */
+export function withCumulativeTotals(
+  levels: OrderBookEntry[],
+): { price: number; amount: number; total: number; depth: number }[] {
+  let running = 0;
+  const rows = levels.map((level) => {
+    running += level.amount;
+    return { ...level, total: running };
+  });
+
+  const max = running || 1;
+  return rows.map((row) => ({ ...row, depth: row.total / max }));
+}
+
+// ── Sample data ──────────────────────────────────────────────────────────────
+
+/**
+ * Deterministic order book used when the marketplace API isn't reachable, so
+ * the trading UI stays explorable in local development. Flagged with
+ * `isSample` so the page can label it.
+ */
+export function generateSampleOrderBook(
+  midPrice: number,
+  levels = 8,
+): OrderBookSnapshot {
+  const price = midPrice > 0 ? midPrice : 100;
+  const tick = price * 0.002;
+
+  const asks: OrderBookEntry[] = Array.from({ length: levels }, (_, i) => ({
+    price: Number((price + tick * (i + 1)).toFixed(4)),
+    amount: Number((25 + ((i * 37) % 60)).toFixed(2)),
+  }));
+
+  const bids: OrderBookEntry[] = Array.from({ length: levels }, (_, i) => ({
+    price: Number((price - tick * (i + 1)).toFixed(4)),
+    amount: Number((30 + ((i * 29) % 55)).toFixed(2)),
+  }));
+
+  return { bids, asks, lastPrice: price, updatedAt: Date.now(), isSample: true };
+}
+
+// ── API ──────────────────────────────────────────────────────────────────────
+
+class TradingApi {
+  /**
+   * Loads the order book. Falls back to sample depth (clearly flagged) when the
+   * endpoint isn't available yet.
+   */
+  async getOrderBook(
+    assetId: string,
+    fallbackPrice: number,
+  ): Promise<OrderBookSnapshot> {
+    try {
+      const res = await fetch(
+        `${API_URL}/api/v1/marketplace/orderbook/${assetId}`,
+      );
+      if (!res.ok) return generateSampleOrderBook(fallbackPrice);
+
+      const data = (await res.json()) as OrderBookSnapshot;
+      return {
+        bids: data.bids ?? [],
+        asks: data.asks ?? [],
+        lastPrice: data.lastPrice ?? fallbackPrice,
+        updatedAt: data.updatedAt ?? Date.now(),
+      };
+    } catch {
+      return generateSampleOrderBook(fallbackPrice);
+    }
+  }
+
+  async getRecentTrades(assetId: string): Promise<RecentTrade[]> {
+    try {
+      const res = await fetch(
+        `${API_URL}/api/v1/marketplace/trades?asset_id=${assetId}&limit=20`,
+      );
+      if (!res.ok) return [];
+      return (await res.json()) as RecentTrade[];
+    } catch {
+      return [];
+    }
+  }
+
+  /** Submits an order. Throws with a readable message so the UI can toast it. */
+  async submitOrder(request: OrderRequest): Promise<OrderReceipt> {
+    const res = await fetch(`${API_URL}/api/v1/marketplace/orders`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        asset_id: request.assetId,
+        side: request.side,
+        order_type: request.type,
+        amount: request.amount,
+        price: request.price,
+        slippage_tolerance: request.slippageTolerance,
+        account: request.account,
+      }),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(
+        detail || `Order rejected by the marketplace (${res.status}).`,
+      );
+    }
+
+    return (await res.json()) as OrderReceipt;
+  }
+}
+
+export const tradingApi = new TradingApi();
+
+// ── Live updates ─────────────────────────────────────────────────────────────
+
+/**
+ * Streams order book updates for one asset. Returns an unsubscribe function.
+ * The caller keeps polling as a fallback — the socket is an optimisation, not
+ * a requirement.
+ */
+export function subscribeToOrderBook(
+  assetId: string,
+  onUpdate: (book: OrderBookSnapshot) => void,
+  onStatusChange?: (status: WSStatus) => void,
+): () => void {
+  const client = new WebSocketClient({
+    url: getWebSocketUrl(),
+    onStatusChange,
+  });
+
+  const unsubscribe = client.subscribe<OrderBookSnapshot & { assetId?: string }>(
+    "orderbook_update",
+    ({ payload }) => {
+      if (payload.assetId && payload.assetId !== assetId) return;
+      onUpdate({
+        bids: payload.bids ?? [],
+        asks: payload.asks ?? [],
+        lastPrice: payload.lastPrice,
+        updatedAt: payload.updatedAt ?? Date.now(),
+      });
+    },
+  );
+
+  client.connect();
+  client.send("subscribe", { channel: "orderbook", assetId });
+
+  return () => {
+    unsubscribe();
+    client.disconnect();
+  };
+}

--- a/frontend/src/lib/wallet-providers.ts
+++ b/frontend/src/lib/wallet-providers.ts
@@ -1,0 +1,559 @@
+/**
+ * Stellar wallet provider registry.
+ *
+ * Each provider is described once here — detection, connect, sign and
+ * disconnect — so the UI (`WalletModal`, `WalletConnect`) never has to know how
+ * an individual wallet exposes itself to the page.
+ *
+ * Freighter talks through its official SDK; the others inject a global object
+ * when their extension (or, for Albedo, their intent script) is present, which
+ * is what `isAvailable()` probes for.
+ */
+
+import * as freighterApi from "@stellar/freighter-api";
+
+import type { StellarWallet } from "@/lib/stellar";
+
+/** Matches the network used by `stellarService`. */
+export const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+export const NETWORK_NAME = "testnet";
+
+const STORAGE_KEY = "kor-assetforge:wallet-provider";
+
+export type WalletProviderId =
+  | "freighter"
+  | "albedo"
+  | "lobstr"
+  | "xbull"
+  | "rabet";
+
+export type WalletErrorCode =
+  | "not-installed"
+  | "rejected"
+  | "unsupported"
+  | "unknown";
+
+/** Wallet failures we can explain to the user, rather than a raw exception. */
+export class WalletError extends Error {
+  readonly code: WalletErrorCode;
+  readonly providerId: WalletProviderId;
+
+  constructor(
+    code: WalletErrorCode,
+    providerId: WalletProviderId,
+    message: string,
+  ) {
+    super(message);
+    this.name = "WalletError";
+    this.code = code;
+    this.providerId = providerId;
+  }
+}
+
+export interface WalletProvider {
+  id: WalletProviderId;
+  name: string;
+  description: string;
+  /** Where to get the wallet when it isn't detected. */
+  installUrl: string;
+  /** Initials shown in the provider tile, so no remote images are needed. */
+  initials: string;
+  /** Tailwind classes for the tile badge. */
+  badgeClassName: string;
+  /** Whether the wallet lives in the browser or opens a hosted popup. */
+  kind: "extension" | "web";
+  /** True when the wallet can be used from this browser right now. */
+  isAvailable: () => Promise<boolean>;
+  /** Requests access and resolves the account's public key. */
+  connect: () => Promise<string>;
+  /** Signs a transaction envelope, returning the signed XDR. */
+  signTransaction: (xdr: string, publicKey: string) => Promise<string>;
+  /** Optional provider-side cleanup; local state is always cleared regardless. */
+  disconnect?: () => Promise<void>;
+}
+
+export interface ConnectedWallet extends StellarWallet {
+  providerId: WalletProviderId;
+  providerName: string;
+}
+
+// ── Injected globals ─────────────────────────────────────────────────────────
+// Minimal structural types for the objects each wallet puts on `window`.
+
+interface AlbedoApi {
+  publicKey: (params: { token?: string }) => Promise<{ pubkey: string }>;
+  tx: (params: {
+    xdr: string;
+    network?: string;
+    pubkey?: string;
+  }) => Promise<{ signed_envelope_xdr: string }>;
+}
+
+interface LobstrApi {
+  isConnected: () => Promise<boolean>;
+  getPublicKey: () => Promise<string>;
+  signTransaction?: (xdr: string) => Promise<string>;
+}
+
+interface XBullApi {
+  connect: (permissions: {
+    canRequestPublicKey: boolean;
+    canRequestSign: boolean;
+  }) => Promise<unknown>;
+  getPublicKey: () => Promise<string>;
+  signXDR: (
+    xdr: string,
+    options?: { publicKey?: string; network?: string; networkPassphrase?: string },
+  ) => Promise<string>;
+  closeConnection?: () => Promise<void>;
+}
+
+interface RabetApi {
+  connect: () => Promise<{ publicKey: string }>;
+  sign: (xdr: string, network: string) => Promise<{ xdr: string }>;
+  disconnect: () => Promise<void>;
+}
+
+declare global {
+  interface Window {
+    albedo?: AlbedoApi;
+    lobstrExtension?: LobstrApi;
+    xBullSDK?: XBullApi;
+    rabet?: RabetApi;
+  }
+}
+
+/** Extensions inject asynchronously, so give a late-loading global a moment. */
+function waitForGlobal<T>(read: () => T | undefined, timeout = 600): Promise<T | undefined> {
+  if (typeof window === "undefined") return Promise.resolve(undefined);
+
+  const immediate = read();
+  if (immediate) return Promise.resolve(immediate);
+
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    const poll = window.setInterval(() => {
+      const value = read();
+      if (value || Date.now() - startedAt >= timeout) {
+        window.clearInterval(poll);
+        resolve(value);
+      }
+    }, 100);
+  });
+}
+
+/** Turns a thrown value into a user-facing wallet error. */
+function toWalletError(
+  providerId: WalletProviderId,
+  error: unknown,
+  fallback: string,
+): WalletError {
+  if (error instanceof WalletError) return error;
+
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  const isRejection = /reject|denied|cancel|declin/i.test(message);
+
+  return new WalletError(
+    isRejection ? "rejected" : "unknown",
+    providerId,
+    isRejection ? "Request rejected in the wallet." : message || fallback,
+  );
+}
+
+// ── Providers ────────────────────────────────────────────────────────────────
+
+const freighter: WalletProvider = {
+  id: "freighter",
+  name: "Freighter",
+  description: "Browser extension by the Stellar Development Foundation",
+  installUrl: "https://www.freighter.app/",
+  initials: "FR",
+  badgeClassName: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",
+  kind: "extension",
+
+  async isAvailable() {
+    try {
+      const { isConnected } = await freighterApi.isConnected();
+      return Boolean(isConnected);
+    } catch {
+      return false;
+    }
+  },
+
+  async connect() {
+    try {
+      // requestAccess prompts for permission the first time and returns the
+      // active account afterwards.
+      const { address, error } = await freighterApi.requestAccess();
+      if (error) throw new Error(error.message);
+      if (!address) {
+        throw new WalletError("rejected", "freighter", "No account was shared.");
+      }
+      return address;
+    } catch (error) {
+      throw toWalletError(
+        "freighter",
+        error,
+        "Could not connect to Freighter.",
+      );
+    }
+  },
+
+  async signTransaction(xdr, publicKey) {
+    const { signedTxXdr, error } = await freighterApi.signTransaction(xdr, {
+      networkPassphrase: NETWORK_PASSPHRASE,
+      address: publicKey,
+    });
+    if (error) throw toWalletError("freighter", new Error(error.message), "Signing failed.");
+    return signedTxXdr;
+  },
+};
+
+const albedo: WalletProvider = {
+  id: "albedo",
+  name: "Albedo",
+  description: "Web wallet — signs in a popup, nothing to install",
+  installUrl: "https://albedo.link/",
+  initials: "AL",
+  badgeClassName: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  kind: "web",
+
+  async isAvailable() {
+    return Boolean(await waitForGlobal(() => window.albedo));
+  },
+
+  async connect() {
+    const api = await waitForGlobal(() => window.albedo);
+    if (!api) {
+      throw new WalletError(
+        "not-installed",
+        "albedo",
+        "Albedo is not available on this page.",
+      );
+    }
+
+    try {
+      const { pubkey } = await api.publicKey({});
+      return pubkey;
+    } catch (error) {
+      throw toWalletError("albedo", error, "Could not connect to Albedo.");
+    }
+  },
+
+  async signTransaction(xdr, publicKey) {
+    const api = window.albedo;
+    if (!api) {
+      throw new WalletError("not-installed", "albedo", "Albedo is not available.");
+    }
+
+    try {
+      const { signed_envelope_xdr } = await api.tx({
+        xdr,
+        network: NETWORK_NAME,
+        pubkey: publicKey,
+      });
+      return signed_envelope_xdr;
+    } catch (error) {
+      throw toWalletError("albedo", error, "Signing failed.");
+    }
+  },
+};
+
+const lobstr: WalletProvider = {
+  id: "lobstr",
+  name: "LOBSTR",
+  description: "LOBSTR signer extension",
+  installUrl: "https://lobstr.co/",
+  initials: "LO",
+  badgeClassName: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+  kind: "extension",
+
+  async isAvailable() {
+    const api = await waitForGlobal(() => window.lobstrExtension);
+    if (!api) return false;
+
+    try {
+      // Present but locked still counts as available — connect() will prompt.
+      await api.isConnected();
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  async connect() {
+    const api = await waitForGlobal(() => window.lobstrExtension);
+    if (!api) {
+      throw new WalletError(
+        "not-installed",
+        "lobstr",
+        "LOBSTR signer extension is not installed.",
+      );
+    }
+
+    try {
+      return await api.getPublicKey();
+    } catch (error) {
+      throw toWalletError("lobstr", error, "Could not connect to LOBSTR.");
+    }
+  },
+
+  async signTransaction(xdr) {
+    const api = window.lobstrExtension;
+    if (!api?.signTransaction) {
+      throw new WalletError(
+        "unsupported",
+        "lobstr",
+        "This LOBSTR version cannot sign transactions from the browser.",
+      );
+    }
+
+    try {
+      return await api.signTransaction(xdr);
+    } catch (error) {
+      throw toWalletError("lobstr", error, "Signing failed.");
+    }
+  },
+};
+
+const xbull: WalletProvider = {
+  id: "xbull",
+  name: "xBull",
+  description: "Open-source Stellar wallet extension",
+  installUrl: "https://xbull.app/",
+  initials: "XB",
+  badgeClassName: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+  kind: "extension",
+
+  async isAvailable() {
+    return Boolean(await waitForGlobal(() => window.xBullSDK));
+  },
+
+  async connect() {
+    const api = await waitForGlobal(() => window.xBullSDK);
+    if (!api) {
+      throw new WalletError(
+        "not-installed",
+        "xbull",
+        "xBull extension is not installed.",
+      );
+    }
+
+    try {
+      await api.connect({ canRequestPublicKey: true, canRequestSign: true });
+      return await api.getPublicKey();
+    } catch (error) {
+      throw toWalletError("xbull", error, "Could not connect to xBull.");
+    }
+  },
+
+  async signTransaction(xdr, publicKey) {
+    const api = window.xBullSDK;
+    if (!api) {
+      throw new WalletError("not-installed", "xbull", "xBull is not available.");
+    }
+
+    try {
+      return await api.signXDR(xdr, {
+        publicKey,
+        network: NETWORK_NAME,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      });
+    } catch (error) {
+      throw toWalletError("xbull", error, "Signing failed.");
+    }
+  },
+
+  async disconnect() {
+    await window.xBullSDK?.closeConnection?.();
+  },
+};
+
+const rabet: WalletProvider = {
+  id: "rabet",
+  name: "Rabet",
+  description: "Lightweight Stellar wallet extension",
+  installUrl: "https://rabet.io/",
+  initials: "RB",
+  badgeClassName: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
+  kind: "extension",
+
+  async isAvailable() {
+    return Boolean(await waitForGlobal(() => window.rabet));
+  },
+
+  async connect() {
+    const api = await waitForGlobal(() => window.rabet);
+    if (!api) {
+      throw new WalletError(
+        "not-installed",
+        "rabet",
+        "Rabet extension is not installed.",
+      );
+    }
+
+    try {
+      const { publicKey } = await api.connect();
+      return publicKey;
+    } catch (error) {
+      throw toWalletError("rabet", error, "Could not connect to Rabet.");
+    }
+  },
+
+  async signTransaction(xdr) {
+    const api = window.rabet;
+    if (!api) {
+      throw new WalletError("not-installed", "rabet", "Rabet is not available.");
+    }
+
+    try {
+      const result = await api.sign(xdr, NETWORK_NAME);
+      return result.xdr;
+    } catch (error) {
+      throw toWalletError("rabet", error, "Signing failed.");
+    }
+  },
+
+  async disconnect() {
+    await window.rabet?.disconnect();
+  },
+};
+
+/** Every provider the app supports, in the order they appear in the modal. */
+export const WALLET_PROVIDERS: readonly WalletProvider[] = [
+  freighter,
+  albedo,
+  lobstr,
+  xbull,
+  rabet,
+];
+
+export function getWalletProvider(
+  id: WalletProviderId,
+): WalletProvider | undefined {
+  return WALLET_PROVIDERS.find((provider) => provider.id === id);
+}
+
+/** Probes every provider in parallel — used to badge the modal tiles. */
+export async function detectWalletProviders(): Promise<
+  Record<WalletProviderId, boolean>
+> {
+  const entries = await Promise.all(
+    WALLET_PROVIDERS.map(
+      async (provider) =>
+        [provider.id, await provider.isAvailable()] as const,
+    ),
+  );
+
+  return Object.fromEntries(entries) as Record<WalletProviderId, boolean>;
+}
+
+// ── Session persistence ──────────────────────────────────────────────────────
+
+/** The provider used last, so the app can offer a one-click reconnect. */
+export function getStoredProviderId(): WalletProviderId | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored && getWalletProvider(stored as WalletProviderId)
+      ? (stored as WalletProviderId)
+      : null;
+  } catch {
+    // Storage can be unavailable (private mode, blocked cookies) — not fatal.
+    return null;
+  }
+}
+
+function storeProviderId(id: WalletProviderId): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    // Ignore — persistence is a convenience, not a requirement.
+  }
+}
+
+function clearStoredProviderId(): void {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore.
+  }
+}
+
+// ── Public actions ───────────────────────────────────────────────────────────
+
+/** Connects through a specific provider and remembers the choice. */
+export async function connectWallet(
+  id: WalletProviderId,
+): Promise<ConnectedWallet> {
+  const provider = getWalletProvider(id);
+  if (!provider) {
+    throw new WalletError("unknown", id, `Unknown wallet provider: ${id}`);
+  }
+
+  const publicKey = await provider.connect();
+  storeProviderId(id);
+
+  return {
+    publicKey,
+    connected: true,
+    providerId: provider.id,
+    providerName: provider.name,
+  };
+}
+
+/** Disconnects the provider (where supported) and forgets the stored choice. */
+export async function disconnectWallet(
+  id: WalletProviderId | null,
+): Promise<void> {
+  if (id) {
+    try {
+      await getWalletProvider(id)?.disconnect?.();
+    } catch {
+      // A failed provider-side disconnect must not block local cleanup.
+    }
+  }
+  clearStoredProviderId();
+}
+
+/** Signs an envelope with the connected wallet. */
+export async function signTransactionWithWallet(
+  wallet: ConnectedWallet,
+  xdr: string,
+): Promise<string> {
+  const provider = getWalletProvider(wallet.providerId);
+  if (!provider) {
+    throw new WalletError(
+      "unknown",
+      wallet.providerId,
+      "The connected wallet is no longer available.",
+    );
+  }
+  return provider.signTransaction(xdr, wallet.publicKey);
+}
+
+/**
+ * Silently restores the previous session on page load. Resolves to `null` when
+ * there is nothing to restore or the wallet would need a fresh prompt.
+ */
+export async function restoreWalletConnection(): Promise<ConnectedWallet | null> {
+  const id = getStoredProviderId();
+  if (!id) return null;
+
+  const provider = getWalletProvider(id);
+  if (!provider || !(await provider.isAvailable())) return null;
+
+  try {
+    const publicKey = await provider.connect();
+    return {
+      publicKey,
+      connected: true,
+      providerId: provider.id,
+      providerName: provider.name,
+    };
+  } catch {
+    // The user has to re-authorise — surface the modal instead of an error.
+    return null;
+  }
+}

--- a/frontend/src/lib/websocket.ts
+++ b/frontend/src/lib/websocket.ts
@@ -1,5 +1,16 @@
 export type WSStatus = "connecting" | "connected" | "disconnected" | "error";
 
+/**
+ * Platform WebSocket endpoint. Uses `NEXT_PUBLIC_WS_URL` when set, otherwise
+ * derives it from the REST API URL (`http://host` → `ws://host/ws`).
+ */
+export function getWebSocketUrl(): string {
+  if (process.env.NEXT_PUBLIC_WS_URL) return process.env.NEXT_PUBLIC_WS_URL;
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+  return `${apiUrl.replace(/^http/, "ws")}/ws`;
+}
+
 export interface WSMessage<T = unknown> {
   type: string;
   payload: T;


### PR DESCRIPTION
## Summary

Four frontend features, one per commit, all built on the existing design system (shadcn-style primitives, CSS variables, light/dark) and branched from the current `main` (`e7fc3e8`) so it merges cleanly.

- **#261 — Toast notifications:** headless store in `lib/toast.ts` (queue, variants, actions, auto-dismiss, `toast.promise`) + `ui/Toast.tsx` portal container mounted in the root layout. The existing `sonner` call sites were migrated to the new API (`toast.success` / `toast.error` signatures are unchanged).
- **#244 — Multi-provider wallet connection:** `lib/wallet-providers.ts` registry for Freighter, Albedo, LOBSTR, xBull and Rabet with detection, connect/sign/disconnect, typed errors and session restore; `WalletModal.tsx` picker + account view; `WalletConnect.tsx` now opens the modal and keeps its original props.
- **#245 — Buy/sell trading interface:** `/trade/[id]` with `OrderBook.tsx` (depth bars, spread, click-to-fill), `OrderForm.tsx` (market/limit, slippage presets, live fee + price-impact calculator) and `OrderConfirmModal.tsx` (full breakdown, slippage limits, ETA, high-impact warnings). Pricing maths lives in `lib/trading.ts`.
- **#268 — Real-time activity feed:** `useActivityFeed.ts` (cursor pagination, filtering, WebSocket updates with de-duplication, day grouping) + `ActivityFeed.tsx` (type filters, event icons, sticky day headers, infinite scroll) and a `/activity` route so it's reachable.

## Notes for the reviewer

- Every feature has explicit loading, empty and error states. Where a backend endpoint doesn't exist yet (order book, activity), the UI falls back to **clearly labelled sample data** rather than an empty screen — the same pattern the analytics page already uses.
- `getWebSocketUrl()` was added to `lib/websocket.ts` and is shared by the trade page and the activity feed; both reuse the existing `WebSocketClient`.
- `components/ui/sonner.tsx` is now unused. It was left in place on purpose to avoid conflicting with branches that still touch it — safe to delete in a follow-up.
- Reusable pieces added along the way: `components/ui/dialog.tsx` (Radix dialog primitive) and the existing `InfiniteScroll` component is reused by the feed.

## Verification

- `npm run lint` and `npx tsc --noEmit`: **no new errors or warnings** — counts are identical to `main` before this branch (36 errors / 34 warnings, all pre-existing).
- `next build` compiles the new code successfully (`✓ Compiled successfully`).
- `/activity` and `/trade/<id>` were rendered against a local dev server and return 200 with the expected markup.

### Pre-existing breakage on `main` (not touched by this PR)

These already fail on `e7fc3e8` and are unrelated to these features — flagging them since they block a fully green build:

1. `src/hooks/useWebSocket.ts` contains JSX (`WSStatusBadge`) in a `.ts` file → parse/type error. Needs renaming to `.tsx`.
2. `src/components/charts/PieChart.tsx` has two recharts v3 typing errors (`label`, `Tooltip formatter`).
3. `next-intl@3` doesn't support Next 16 (peer conflict requires `--legacy-peer-deps`), and at runtime every route 500s with "Couldn't find next-intl config file".

Closes #261
Closes #244
Closes #245
Closes #268
